### PR TITLE
Metrics Phase 1 (#180)

### DIFF
--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/losses/CategoricalCrossentropy.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/losses/CategoricalCrossentropy.java
@@ -69,7 +69,7 @@ import static org.tensorflow.framework.utils.CastHelper.cast;
 public class CategoricalCrossentropy extends Loss {
   public static final boolean FROM_LOGITS_DEFAULT = false;
   public static final float LABEL_SMOOTHING_DEFAULT = 0.0f;
-  public static final int DEFAULT_AXIS = -1;
+  public static final int DEFAULT_AXIS = Losses.CHANNELS_LAST;
 
   private final boolean fromLogits;
   private final float labelSmoothing;
@@ -203,8 +203,9 @@ public class CategoricalCrossentropy extends Loss {
    *    confidence on label values are relaxed. e.g. <code>labelSmoothing=0.2</code> means that we will use a
    *    value of <code>0.1</code> for label <code>0</code> and <code>0.9</code> for label <code>1</code>
    * @param reduction Type of Reduction to apply to loss.
-   * @param axis The channels axis. <code>axis=-1</code> corresponds to data format `Channels Last'
-   *     and <code>axis=1</code> corresponds to data format 'Channels First'.
+   * @param axis The channels axis. <code>axis=-1</code> corresponds to data format "Channels Last"
+   *     and <code>axis=1</code> corresponds to data format "Channels First".
+   *     {@link Losses#CHANNELS_LAST} and {@link Losses#CHANNELS_FIRST}
    * @throws IllegalArgumentException if labelSmoothing is not in the inclusive range of 0. - 1.
    */
   public CategoricalCrossentropy(

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/losses/Losses.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/losses/Losses.java
@@ -36,6 +36,9 @@ public class Losses {
   /** Default Fuzz factor. */
   public static final float EPSILON = 1e-7f;
 
+  public static final int CHANNELS_LAST = -1;
+  public static final int CHANNELS_FIRST = 1;
+
   /**
    * Calculates the mean absolute error between labels and predictions.
    *
@@ -239,7 +242,7 @@ public class Losses {
       tLabels = smoothCategoricalLabels(tf, tLabels, labelSmoothing);
     }
     if (fromLogits) {
-      return tf.nn.softmaxCrossEntropyWithLogits(tLabels, predictions, -1);
+      return tf.nn.softmaxCrossEntropyWithLogits(tLabels, predictions, axis);
     }
     /* TODO
     if (!(predictions instanceof Variable) && (!tf.scope().env().isEager())) {

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/BinaryCrossentropy.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/BinaryCrossentropy.java
@@ -1,0 +1,66 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================*/
+package org.tensorflow.framework.metrics;
+
+import org.tensorflow.Operand;
+import org.tensorflow.framework.losses.Losses;
+import org.tensorflow.framework.metrics.impl.LossMetric;
+import org.tensorflow.framework.metrics.impl.MeanMetricWrapper;
+import org.tensorflow.op.Ops;
+import org.tensorflow.types.family.TNumber;
+
+/**
+ * A Metric that computes the binary cross-entropy loss between true labels and predicted labels.
+ *
+ * <p>This is the crossentropy metric class to be used when there are only two label classes (0 and
+ * 1).
+ *
+ * @param <U> the data type for the predictions.
+ * @param <T> The data type for the metric result
+ */
+public class BinaryCrossentropy<U extends TNumber, T extends TNumber>
+    extends MeanMetricWrapper<U, T> implements LossMetric<T> {
+
+  private final boolean fromLogits;
+  private final float labelSmoothing;
+
+  /**
+   * Creates a BinaryCrossentropy metric
+   *
+   * @param tf the TensorFlow Ops
+   * @param name the name of this metric, if null then metric name is {@link Class#getSimpleName()}.
+   * @param fromLogits Whether to interpret predictions as a tensor of logit values as opposed to a probability distribution.
+   * @param labelSmoothing value used to smooth labels, When 0, no smoothing occurs. When &gt; 0,
+   *     compute the loss between the predicted labels and a smoothed version of the true labels,
+   *     where the smoothing squeezes the labels towards 0.5. Larger values of label_smoothing
+   *     correspond to heavier smoothing.
+   * @param seed the seed for random number generation. An initializer created with a given seed
+   *     will always produce the same random tensor for a given shape and data type.
+   * @param type the type for the variables and result
+   */
+  public BinaryCrossentropy(
+      Ops tf, String name, boolean fromLogits, float labelSmoothing, long seed, Class<T> type) {
+    super(tf, name, seed, type);
+    setLoss(this);
+    this.fromLogits = fromLogits;
+    this.labelSmoothing = labelSmoothing;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public <V extends TNumber> Operand<T> call(Operand<V> labels, Operand<T> predictions) {
+    return Losses.binaryCrossentropy(getTF(), labels, predictions, fromLogits, labelSmoothing);
+  }
+}

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/CategoricalCrossentropy.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/CategoricalCrossentropy.java
@@ -1,0 +1,105 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================*/
+package org.tensorflow.framework.metrics;
+
+import org.tensorflow.Operand;
+import org.tensorflow.framework.losses.Losses;
+import org.tensorflow.framework.metrics.impl.LossMetric;
+import org.tensorflow.framework.metrics.impl.MeanMetricWrapper;
+import org.tensorflow.op.Ops;
+import org.tensorflow.types.family.TNumber;
+
+/**
+ * A Metric that computes the categorical cross-entropy loss between true labels and predicted
+ * labels.
+ *
+ * <p>This is the crossentropy metric class to be used when there are multiple label classes (2 or
+ * more). The labels should be given as a one_hot representation. eg., When labels values are <code>
+ * [2, 0, 1]</code>, the labels Operand contains = <code>[[0, 0, 1], [1, 0, 0], [0, 1, 0]]
+ * </code>.
+ *
+ * @param <U> the data type for the predictions.
+ * @param <T> The data type for the metric result
+ */
+public class CategoricalCrossentropy<U extends TNumber, T extends TNumber>
+    extends MeanMetricWrapper<U, T> implements LossMetric<T> {
+
+  private final boolean fromLogits;
+  private final float labelSmoothing;
+  private final int axis;
+
+  /**
+   * Creates a CategoricalCrossentropy metric that computes the crossentropy metric between the
+   * labels and predictions.
+   *
+   * <p>Uses a {@link Losses#CHANNELS_LAST} for the channel axis.
+   *
+   * @param tf the TensorFlow Ops
+   * @param name the name of this metric, if null then metric name is {@link Class#getSimpleName()}.
+   * @param fromLogits Whether to interpret predictions as a tensor of logit values oras opposed to a probability distribution.
+   * @param labelSmoothing value used to smooth labels, When &gt; 0, label values are smoothed,
+   *     meaning the confidence on label values are relaxed. e.g. <code>labelSmoothing=0.2</code>
+   *     means that we will use a value of <code>0.1</code> for label <code>0</code> and <code>0.9
+   *     </code> for label <code>1</code>
+   * @param seed the seed for random number generation. An initializer created with a given seed
+   *     will always produce the same random tensor for a given shape and data type.
+   * @param type the type for the variables and result
+   */
+  public CategoricalCrossentropy(
+      Ops tf, String name, boolean fromLogits, float labelSmoothing, long seed, Class<T> type) {
+    this(tf, name, fromLogits, labelSmoothing, Losses.CHANNELS_LAST, seed, type);
+  }
+
+  /**
+   * Creates a CategoricalCrossentropy metric that computes the crossentropy metric between the
+   * labels and predictions.
+   *
+   * @param tf the TensorFlow Ops
+   * @param name the name of this metric, if null then metric name is {@link Class#getSimpleName()}.
+   * @param fromLogits Whether to interpret predictions as a tensor of logit values as opposed to a probability distribution.
+   * @param labelSmoothing value used to smooth labels, When &gt; 0, label values are smoothed,
+   *     meaning the confidence on label values are relaxed. e.g. <code>labelSmoothing=0.2</code>
+   *     means that we will use a value of <code>0.1</code> for label <code>0</code> and <code>0.9
+   *     </code> for label <code>1</code>
+   * @param axis Int specifying the channels axis. <code>axis={@link Losses#CHANNELS_LAST}</code>
+   *     corresponds to data format <code>channels_last</code>, and <code>
+   *     axis={@link Losses#CHANNELS_FIRST}</code> corresponds to data format <code>
+   *     channels_first</code>.
+   * @param seed the seed for random number generation. An initializer created with a given seed
+   *     will always produce the same random tensor for a given shape and data type.
+   * @param type the type for the variables and result
+   */
+  public CategoricalCrossentropy(
+      Ops tf,
+      String name,
+      boolean fromLogits,
+      float labelSmoothing,
+      int axis,
+      long seed,
+      Class<T> type) {
+    super(tf, name, seed, type);
+    setLoss(this);
+    this.fromLogits = fromLogits;
+    this.labelSmoothing = labelSmoothing;
+    this.axis = axis;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public <V extends TNumber> Operand<T> call(Operand<V> labels, Operand<T> predictions) {
+    return Losses.categoricalCrossentropy(
+        getTF(), labels, predictions, fromLogits, labelSmoothing, axis);
+  }
+}

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/CategoricalHinge.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/CategoricalHinge.java
@@ -1,0 +1,52 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================*/
+package org.tensorflow.framework.metrics;
+
+import org.tensorflow.Operand;
+import org.tensorflow.framework.losses.Losses;
+import org.tensorflow.framework.metrics.impl.LossMetric;
+import org.tensorflow.framework.metrics.impl.MeanMetricWrapper;
+import org.tensorflow.op.Ops;
+import org.tensorflow.types.family.TNumber;
+
+/**
+ * A Metric that computes the categorical hinge loss metric between labels and predictions.
+ *
+ * @param <U> the data type for the predictions.
+ * @param <T> The data type for the metric result
+ */
+public class CategoricalHinge<U extends TNumber, T extends TNumber> extends MeanMetricWrapper<U, T>
+    implements LossMetric<T> {
+
+  /**
+   * Creates a CategoricalHinge metric
+   *
+   * @param tf the TensorFlow Ops
+   * @param name the name of this metric, if null then metric name is {@link Class#getSimpleName()}.
+   * @param seed the seed for random number generation. An initializer created with a given seed
+   *     will always produce the same random tensor for a given shape and data type.
+   * @param type the type for the variables and result
+   */
+  public CategoricalHinge(Ops tf, String name, long seed, Class<T> type) {
+    super(tf, name, seed, type);
+    setLoss(this);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public <V extends TNumber> Operand<T> call(Operand<V> labels, Operand<T> predictions) {
+    return Losses.categoricalHinge(getTF(), labels, predictions);
+  }
+}

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/CosineSimilarity.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/CosineSimilarity.java
@@ -1,0 +1,83 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================*/
+package org.tensorflow.framework.metrics;
+
+import org.tensorflow.Operand;
+import org.tensorflow.framework.metrics.impl.LossMetric;
+import org.tensorflow.framework.metrics.impl.MeanMetricWrapper;
+import org.tensorflow.op.Ops;
+import org.tensorflow.types.family.TNumber;
+
+/**
+ * A metric that computes the cosine similarity metric between labels and predictions.
+ *
+ * @param <U> the data type for the predictions.
+ * @param <T> The data type for the metric result.
+ */
+public class CosineSimilarity<U extends TNumber, T extends TNumber> extends MeanMetricWrapper<U, T>
+    implements LossMetric<T> {
+  public static final int DEFAULT_AXIS = -1;
+  private final int[] axis;
+
+  /**
+   * Creates a metric that computes the cosine similarity metric between labels and predictions with
+   * a default axis, {@link #DEFAULT_AXIS}
+   *
+   * @param tf the TensorFlow Ops
+   * @param name the name of this metric, if null then metric name is {@link Class#getSimpleName()}.
+   * @param seed the seed for random number generation. An initializer created with a given seed
+   *     will always produce the same random tensor for a given shape and data type.
+   * @param type the type for the variables and result
+   */
+  public CosineSimilarity(Ops tf, String name, long seed, Class<T> type) {
+    this(tf, name, DEFAULT_AXIS, seed, type);
+  }
+
+  /**
+   * Creates a metric that computes the cosine similarity metric between labels and predictions.
+   *
+   * @param tf the TensorFlow Ops
+   * @param name the name of this metric, if null then metric name is {@link Class#getSimpleName()}.
+   * @param axis The dimension along which the cosine similarity is computed.
+   * @param seed the seed for random number generation. An initializer created with a given seed
+   *     will always produce the same random tensor for a given shape and data type.
+   * @param type the type for the variables and result
+   */
+  public CosineSimilarity(Ops tf, String name, int axis, long seed, Class<T> type) {
+    this(tf, name, new int[] {axis}, seed, type);
+  }
+  /**
+   * Creates a CosineSimilarity metric
+   *
+   * @param tf the TensorFlow Ops
+   * @param name the name of this metric, if null then metric name is {@link Class#getSimpleName()}.
+   * @param axis The dimension along which the cosine similarity is computed.
+   * @param seed the seed for random number generation. An initializer created with a given seed
+   *     will always produce the same random tensor for a given shape and data type.
+   * @param type the type for the variables and result
+   */
+  public CosineSimilarity(Ops tf, String name, int[] axis, long seed, Class<T> type) {
+    super(tf, name, seed, type);
+    this.axis = axis;
+    setLoss(this);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public <V extends TNumber> Operand<T> call(Operand<V> labels, Operand<T> predictions) {
+    // NOTE: cosineProximity is a different algorithm than Losses.cosineSimilarity
+    return Metrics.cosineProximity(getTF(), labels, predictions, axis);
+  }
+}

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/Hinge.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/Hinge.java
@@ -1,0 +1,52 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================*/
+package org.tensorflow.framework.metrics;
+
+import org.tensorflow.Operand;
+import org.tensorflow.framework.losses.Losses;
+import org.tensorflow.framework.metrics.impl.LossMetric;
+import org.tensorflow.framework.metrics.impl.MeanMetricWrapper;
+import org.tensorflow.op.Ops;
+import org.tensorflow.types.family.TNumber;
+
+/**
+ * A metric that computes the hinge loss metric between labels and predictions.
+ *
+ * @param <U> the data type for the predictions.
+ * @param <T> The data type for the metric result.
+ */
+public class Hinge<U extends TNumber, T extends TNumber> extends MeanMetricWrapper<U, T>
+    implements LossMetric<T> {
+
+  /**
+   * Creates a Hinge metric
+   *
+   * @param tf the TensorFlow Ops
+   * @param name the name of this metric, if null then metric name is {@link Class#getSimpleName()}.
+   * @param seed the seed for random number generation. An initializer created with a given seed
+   *     will always produce the same random tensor for a given shape and data type.
+   * @param type the type for the variables and result
+   */
+  public Hinge(Ops tf, String name, long seed, Class<T> type) {
+    super(tf, name, seed, type);
+    setLoss(this);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public <V extends TNumber> Operand<T> call(Operand<V> labels, Operand<T> predictions) {
+    return Losses.hinge(getTF(), labels, predictions);
+  }
+}

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/KLDivergence.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/KLDivergence.java
@@ -1,0 +1,53 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================*/
+package org.tensorflow.framework.metrics;
+
+import org.tensorflow.Operand;
+import org.tensorflow.framework.losses.Losses;
+import org.tensorflow.framework.metrics.impl.LossMetric;
+import org.tensorflow.framework.metrics.impl.MeanMetricWrapper;
+import org.tensorflow.op.Ops;
+import org.tensorflow.types.family.TNumber;
+
+/**
+ * A metric that computes the Kullback-Leibler divergence loss metric between labels and
+ * predictions.
+ *
+ * @param <U> the data type for the predictions.
+ * @param <T> The data type for the metric result.
+ */
+public class KLDivergence<U extends TNumber, T extends TNumber> extends MeanMetricWrapper<U, T>
+    implements LossMetric<T> {
+
+  /**
+   * Creates a KLDivergence metric
+   *
+   * @param tf the TensorFlow Ops
+   * @param name the name of this metric, if null then metric name is {@link Class#getSimpleName()}.
+   * @param seed the seed for random number generation. An initializer created with a given seed
+   *     will always produce the same random tensor for a given shape and data type.
+   * @param type the type for the variables and result
+   */
+  public KLDivergence(Ops tf, String name, long seed, Class<T> type) {
+    super(tf, name, seed, type);
+    setLoss(this);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public <V extends TNumber> Operand<T> call(Operand<V> labels, Operand<T> predictions) {
+    return Losses.kullbackLeiblerDivergence(getTF(), labels, predictions);
+  }
+}

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/LogCoshError.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/LogCoshError.java
@@ -1,0 +1,53 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================*/
+package org.tensorflow.framework.metrics;
+
+import org.tensorflow.Operand;
+import org.tensorflow.framework.losses.Losses;
+import org.tensorflow.framework.metrics.impl.LossMetric;
+import org.tensorflow.framework.metrics.impl.MeanMetricWrapper;
+import org.tensorflow.op.Ops;
+import org.tensorflow.types.family.TNumber;
+
+/**
+ * A metric that computes the logarithm of the hyperbolic cosine of the prediction error metric
+ * between labels and predictions.
+ *
+ * @param <U> the data type for the predictions.
+ * @param <T> The data type for the metric result.
+ */
+public class LogCoshError<U extends TNumber, T extends TNumber> extends MeanMetricWrapper<U, T>
+    implements LossMetric<T> {
+
+  /**
+   * Creates a LogCoshError metric
+   *
+   * @param tf the TensorFlow Ops
+   * @param name the name of this metric, if null then metric name is {@link Class#getSimpleName()}.
+   * @param seed the seed for random number generation. An initializer created with a given seed
+   *     will always produce the same random tensor for a given shape and data type.
+   * @param type the type for the variables and result
+   */
+  public LogCoshError(Ops tf, String name, long seed, Class<T> type) {
+    super(tf, name, seed, type);
+    setLoss(this);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public <V extends TNumber> Operand<T> call(Operand<V> labels, Operand<T> predictions) {
+    return Losses.logCosh(getTF(), labels, predictions);
+  }
+}

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/Mean.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/Mean.java
@@ -1,0 +1,41 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================*/
+package org.tensorflow.framework.metrics;
+
+import org.tensorflow.framework.metrics.impl.Reduce;
+import org.tensorflow.op.Ops;
+import org.tensorflow.types.family.TNumber;
+
+/**
+ * A metric that that implements a weighted mean {@link MetricReduction#WEIGHTED_MEAN }
+ *
+ * @param <U> The data type for the metric values
+ * @param <T> The data type for the metric result
+ */
+public class Mean<U extends TNumber, T extends TNumber> extends Reduce<U, T> {
+
+  /**
+   * Creates a Reducible Metric with a metric reductions of {@link MetricReduction#SUM}
+   *
+   * @param tf the TensorFlow Ops
+   * @param name the name for this metric. If null, name defaults to {@link Class#getSimpleName()}.
+   * @param seed the seed for random number generation. An initializer created with a given seed
+   *     will always produce the same random tensor for a given shape and data type.
+   * @param type the type for the variables and result
+   */
+  protected Mean(Ops tf, String name, long seed, Class<T> type) {
+    super(tf, name, MetricReduction.WEIGHTED_MEAN, seed, type);
+  }
+}

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/MeanAbsoluteError.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/MeanAbsoluteError.java
@@ -1,0 +1,52 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================*/
+package org.tensorflow.framework.metrics;
+
+import org.tensorflow.Operand;
+import org.tensorflow.framework.losses.Losses;
+import org.tensorflow.framework.metrics.impl.LossMetric;
+import org.tensorflow.framework.metrics.impl.MeanMetricWrapper;
+import org.tensorflow.op.Ops;
+import org.tensorflow.types.family.TNumber;
+
+/**
+ * A metric that computes the mean of absolute difference between labels and predictions.
+ *
+ * @param <U> the data type for the predictions.
+ * @param <T> The data type for the metric result.
+ */
+public class MeanAbsoluteError<U extends TNumber, T extends TNumber> extends MeanMetricWrapper<U, T>
+    implements LossMetric<T> {
+
+  /**
+   * Creates a Mean Absolute Error metric
+   *
+   * @param tf the TensorFlow Ops
+   * @param name the name of this metric, if null then metric name is {@link Class#getSimpleName()}.
+   * @param seed the seed for random number generation. An initializer created with a given seed
+   *     will always produce the same random tensor for a given shape and data type.
+   * @param type the type for the variables and result
+   */
+  public MeanAbsoluteError(Ops tf, String name, long seed, Class<T> type) {
+    super(tf, name, seed, type);
+    setLoss(this);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public <V extends TNumber> Operand<T> call(Operand<V> labels, Operand<T> predictions) {
+    return Losses.meanAbsoluteError(getTF(), labels, predictions);
+  }
+}

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/MeanAbsolutePercentageError.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/MeanAbsolutePercentageError.java
@@ -1,0 +1,52 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================*/
+package org.tensorflow.framework.metrics;
+
+import org.tensorflow.Operand;
+import org.tensorflow.framework.losses.Losses;
+import org.tensorflow.framework.metrics.impl.LossMetric;
+import org.tensorflow.framework.metrics.impl.MeanMetricWrapper;
+import org.tensorflow.op.Ops;
+import org.tensorflow.types.family.TNumber;
+
+/**
+ * A metric that computes the mean of absolute difference between labels and predictions.
+ *
+ * @param <U> the data type for the predictions.
+ * @param <T> The data type for the metric result.
+ */
+public class MeanAbsolutePercentageError<U extends TNumber, T extends TNumber>
+    extends MeanMetricWrapper<U, T> implements LossMetric<T> {
+
+  /**
+   * Creates a Mean Absolute Error metric
+   *
+   * @param tf the TensorFlow Ops
+   * @param name the name of this metric, if null then metric name is {@link Class#getSimpleName()}.
+   * @param seed the seed for random number generation. An initializer created with a given seed
+   *     will always produce the same random tensor for a given shape and data type.
+   * @param type the type for the variables and result
+   */
+  public MeanAbsolutePercentageError(Ops tf, String name, long seed, Class<T> type) {
+    super(tf, name, seed, type);
+    setLoss(this);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public <V extends TNumber> Operand<T> call(Operand<V> labels, Operand<T> predictions) {
+    return Losses.meanAbsolutePercentageError(getTF(), labels, predictions);
+  }
+}

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/MeanSquaredError.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/MeanSquaredError.java
@@ -1,0 +1,52 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================*/
+package org.tensorflow.framework.metrics;
+
+import org.tensorflow.Operand;
+import org.tensorflow.framework.losses.Losses;
+import org.tensorflow.framework.metrics.impl.LossMetric;
+import org.tensorflow.framework.metrics.impl.MeanMetricWrapper;
+import org.tensorflow.op.Ops;
+import org.tensorflow.types.family.TNumber;
+
+/**
+ * A metric that computes the mean of absolute difference between labels and predictions.
+ *
+ * @param <U> the data type for the predictions.
+ * @param <T> The data type for the metric result.
+ */
+public class MeanSquaredError<U extends TNumber, T extends TNumber> extends MeanMetricWrapper<U, T>
+    implements LossMetric<T> {
+
+  /**
+   * Creates a Mean Absolute Error metric
+   *
+   * @param tf the TensorFlow Ops
+   * @param name the name of this metric, if null then metric name is {@link Class#getSimpleName()}.
+   * @param seed the seed for random number generation. An initializer created with a given seed
+   *     will always produce the same random tensor for a given shape and data type.
+   * @param type the type for the variables and result
+   */
+  public MeanSquaredError(Ops tf, String name, long seed, Class<T> type) {
+    super(tf, name, seed, type);
+    setLoss(this);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public <V extends TNumber> Operand<T> call(Operand<V> labels, Operand<T> predictions) {
+    return Losses.meanSquaredError(getTF(), labels, predictions);
+  }
+}

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/MeanSquaredLogarithmicError.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/MeanSquaredLogarithmicError.java
@@ -1,0 +1,52 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================*/
+package org.tensorflow.framework.metrics;
+
+import org.tensorflow.Operand;
+import org.tensorflow.framework.losses.Losses;
+import org.tensorflow.framework.metrics.impl.LossMetric;
+import org.tensorflow.framework.metrics.impl.MeanMetricWrapper;
+import org.tensorflow.op.Ops;
+import org.tensorflow.types.family.TNumber;
+
+/**
+ * A metric that computes the mean of absolute difference between labels and predictions.
+ *
+ * @param <U> the data type for the predictions.
+ * @param <T> The data type for the metric result.
+ */
+public class MeanSquaredLogarithmicError<U extends TNumber, T extends TNumber>
+    extends MeanMetricWrapper<U, T> implements LossMetric<T> {
+
+  /**
+   * Creates a Mean Absolute Error metric
+   *
+   * @param tf the TensorFlow Ops
+   * @param name the name of this metric, if null then metric name is {@link Class#getSimpleName()}.
+   * @param seed the seed for random number generation. An initializer created with a given seed
+   *     will always produce the same random tensor for a given shape and data type.
+   * @param type the type for the variables and result
+   */
+  public MeanSquaredLogarithmicError(Ops tf, String name, long seed, Class<T> type) {
+    super(tf, name, seed, type);
+    setLoss(this);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public <V extends TNumber> Operand<T> call(Operand<V> labels, Operand<T> predictions) {
+    return Losses.meanSquaredLogarithmicError(getTF(), labels, predictions);
+  }
+}

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/Metric.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/Metric.java
@@ -1,0 +1,193 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================*/
+package org.tensorflow.framework.metrics;
+
+import org.tensorflow.Operand;
+import org.tensorflow.op.Op;
+import org.tensorflow.op.Ops;
+import org.tensorflow.types.family.TNumber;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Base class for Metrics
+ *
+ * @param <U> The data type for the metric values
+ * @param <T> The data type for the metric result
+ */
+public abstract class Metric<U extends TNumber, T extends TNumber> {
+
+  /** The TensorFlow Ops */
+  private final Ops tf;
+
+  /** The seed for random number generation */
+  private final long seed;
+
+  /** The name for this metric. Defaults to {@link Class#getSimpleName()}. */
+  private final String name;
+
+  /**
+   * Creates a Metric with a name of {@link Class#getSimpleName()}
+   *
+   * @param tf the TensorFlow Ops
+   * @param seed the seed for random number generation. An initializer created with a given seed
+   *     will always produce the same random tensor for a given shape and data type.
+   */
+  protected Metric(Ops tf, long seed) {
+    this(tf, null, seed);
+  }
+
+  /**
+   * Creates a Metric
+   *
+   * @param tf the TensorFlow Ops
+   * @param name the name for this metric. If null, name defaults to {@link Class#getSimpleName()}.
+   * @param seed the seed for random number generation. An initializer created with a given seed
+   *     will always produce the same random tensor for a given shape and data type.
+   */
+  protected Metric(Ops tf, String name, long seed) {
+    if (!tf.scope().env().isGraph()) {
+      throw new IllegalArgumentException("Metrics are required to execute in Graph mode.");
+    }
+    this.seed = seed;
+    this.name = name != null ? name : this.getClass().getSimpleName();
+    this.tf = tf.withName(this.getClass().getSimpleName());
+  }
+
+  /**
+   * Creates a List of Operations to update the metric state based on input values.
+   *
+   * <p>This is an empty implementation that should be overridden in a subclass, if needed.
+   *
+   * @param values the inputs to be passed to update state, this may not be null
+   * @param sampleWeights sample weights to be applied to values, may be null.
+   * @return a List of Operations to update the metric state
+   * @param <S> the data type for sampleWeights
+   */
+  @SuppressWarnings({"unchecked", "unused"})
+  public <S extends TNumber> List<Op> updateStateList(Operand<U> values, Operand<S> sampleWeights) {
+    return Collections.EMPTY_LIST;
+  }
+
+  /**
+   * Creates a List of Operations to update the metric state based on labels and predictions.
+   *
+   * <p>This is an empty implementation that should be overridden in a sub class, if needed.
+   *
+   * @param labels the labels
+   * @param predictions the predictions
+   * @param sampleWeights sample weights to be applied to values, may be null.
+   * @param <V> the data type for the labels
+   * @param <S> the data type for the sampleWeights
+   * @return a List of Operations to update the metric state
+   */
+  @SuppressWarnings({"unchecked", "unused"})
+  public <V extends TNumber, S extends TNumber> List<Op> updateStateList(
+      Operand<V> labels, Operand<U> predictions, Operand<S> sampleWeights) {
+    return Collections.EMPTY_LIST;
+  }
+
+  /**
+   * Creates a NoOp Operation with control dependencies to update the metric state
+   *
+   * @param values the inputs to be passed to update state, this may not be null
+   * @param sampleWeights sample weights to be applied to values, may be null.
+   * @param <S> the data type for sampleWeights
+   * @return the Operation to update the metric state
+   */
+  public final <S extends TNumber> Op updateState(Operand<U> values, Operand<S> sampleWeights) {
+    List<Op> controlOps = updateStateList(values, sampleWeights);
+    return tf.withSubScope("updateState").withControlDependencies(controlOps).noOp();
+  }
+
+  /**
+   * Creates a NoOp Operation with control dependencies to update the metric state
+   *
+   * @param labels the labels
+   * @param predictions the predictions
+   * @param sampleWeights sample weights to be applied to values, may be null.
+   * @param <V> the data type for the labels
+   * @param <S> the data type for the sampleWeights
+   * @return the Operation to update the metric state
+   */
+  public final <V extends TNumber, S extends TNumber> Op updateState(
+      Operand<V> labels, Operand<U> predictions, Operand<S> sampleWeights) {
+    List<Op> controlOps = updateStateList(labels, predictions, sampleWeights);
+    return tf.withSubScope("updateState").withControlDependencies(controlOps).noOp();
+  }
+
+  /**
+   * Gets the current result of the metric
+   *
+   * @return the result, possibly with control dependencies
+   */
+  public abstract Operand<T> result();
+
+  /**
+   * Resets any state variables to their initial values
+   *
+   * @return the control operation for doing the reset
+   */
+  public abstract Op resetStates();
+
+  /**
+   * Calls update state once, followed by a call to get the result
+   *
+   * @param values the inputs to be passed to update state, this may not be null
+   * @param sampleWeights sample weights to be applied to values, may be null.
+   * @return the result, possibly with control dependencies
+   * @param <S> the data type for the sampleWeights.
+   */
+  public final <S extends TNumber> Operand<T> callOnce(
+      Operand<U> values, Operand<S> sampleWeights) {
+    List<Op> controlOps = updateStateList(values, sampleWeights);
+    Ops ltf = tf.withSubScope("callOnce").withControlDependencies(controlOps);
+    return ltf.identity(result());
+  }
+
+  /**
+   * Gets a formatted name for a variable, in the form {@link #name} + "_" + varName.
+   *
+   * @param varName the base name for the variable
+   * @return the formatted variable name
+   */
+  protected String getVariableName(String varName) {
+    return String.format("%s_%s", this.name, varName);
+  }
+
+  /**
+   * Gets the TensorFlow Ops
+   *
+   * @return the TensorFlow Ops
+   */
+  public Ops getTF() {
+    return tf;
+  }
+
+  /**
+   * Gets the name of this metric.
+   *
+   * @return the name of this metric
+   */
+  public String getName() {
+    return name;
+  }
+
+  /** The random number generator seed value */
+  public long getSeed() {
+    return seed;
+  }
+}

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/MetricReduction.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/MetricReduction.java
@@ -1,0 +1,26 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================*/
+package org.tensorflow.framework.metrics;
+
+/** Defines the different types of metric reductions */
+public enum MetricReduction {
+
+  /** Scalar sum of weighted values. */
+  SUM,
+  /** Scalar sum of weighted values divided by number of elements. */
+  SUM_OVER_BATCH_SIZE,
+  /** Scalar sum of weighted values divided by sum of weights. */
+  WEIGHTED_MEAN
+}

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/Metrics.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/Metrics.java
@@ -1,0 +1,134 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================*/
+package org.tensorflow.framework.metrics;
+
+import org.tensorflow.Operand;
+import org.tensorflow.framework.utils.CastHelper;
+import org.tensorflow.op.Ops;
+import org.tensorflow.op.core.ReduceSum;
+import org.tensorflow.types.TFloat32;
+import org.tensorflow.types.family.TNumber;
+
+/** Helper class with built-in metrics functions. */
+public class Metrics {
+
+  public static final float L2_NORM_EPSILON = 1e-12f;
+
+  /**
+   * Computes how often targets are in the top K predictions.
+   *
+   * <p>Standalone usage:
+   *
+   * <pre>
+   *     Operand&lt;TInt32&gt; labels = tf.constant(new int[][]
+   *                                    {{0, 0, 1}, {0, 1, 0}});
+   *     Operand&lt;TFloat32&gt; predictions = tf.constant(new float[][]
+   *                                    {{0.1f, 0.9f, 0.8f}, {0.05f, 0.95f, 0f}});
+   *     Operand&lt;TFloat32&gt; m = Metrics.topKCategoricalAccuracy(
+   *                                    labels, predictions, 3)
+   *     //m.shape().toString == "[2]"
+   * </pre>
+   *
+   * @param tf the TensorFlow Ops.
+   * @param labels the ground truth values.
+   * @param predictions The prediction values.
+   * @param k Number of top elements to look at for computing accuracy.
+   * @param <T> the data type for the predictions and results
+   * @param <U> the data type ofr the labels.
+   * @return the Operand for the Top K categorical accuracy value.
+   */
+  public static <T extends TNumber, U extends TNumber> Operand<T> topKCategoricalAccuracy(
+      Ops tf, Operand<U> labels, Operand<T> predictions, long k) {
+    Operand<TFloat32> fPredictions = CastHelper.cast(tf, predictions, TFloat32.class);
+    return CastHelper.cast(
+        tf,
+        tf.nn.inTopK(fPredictions, tf.math.argMax(labels, tf.constant(-1)), tf.constant(k)),
+        predictions.type());
+  }
+
+  /**
+   * Computes the cosine similarity between labels and predictions.
+   *
+   * @param tf the TensorFlow Ops
+   * @param labels The ground truth values.
+   * @param predictions The prediction values.
+   * @param axes The dimensions along which the cosine similarity is computed.
+   * @param <U> the data type for the labels
+   * @param <T> the data type for the predictions and result
+   * @return Cosine similarity value.
+   */
+  public static <T extends TNumber, U extends TNumber> Operand<T> cosineProximity(
+      Ops tf, Operand<U> labels, Operand<T> predictions, int[] axes) {
+    Operand<T> labelsNorm = CastHelper.cast(tf, labels, predictions.type());
+    labelsNorm = l2Normalize(tf, labelsNorm, axes);
+
+    Operand<T> predictionsNorm = l2Normalize(tf, predictions, axes);
+    Operand<T> mathMul = tf.math.mul(labelsNorm, predictionsNorm);
+    return tf.reduceSum(mathMul, tf.constant(axes), ReduceSum.keepDims(Boolean.FALSE));
+  }
+
+  /**
+   * Normalizes along dimension <code>axis</code> using an L2 norm with an epsilon of {@link
+   * #L2_NORM_EPSILON}.
+   *
+   * <p>For a 1-D tensor with <code>axis = 0</code>, computes
+   *
+   * <pre>
+   *       output = x / sqrt(max(sum(x**2), epsilon))
+   * </pre>
+   *
+   * <p>For <code>x</code> with more dimensions, independently normalizes each 1-D slice along
+   * dimension <code>axis</code>.
+   *
+   * @param tf The TensorFlow ops
+   * @param x The operand to normalize
+   * @param axes Dimension(s) along which to normalize.
+   * @param <U> The data type for x.
+   * @return the normalized values of x.
+   */
+  public static <U extends TNumber> Operand<U> l2Normalize(Ops tf, Operand<U> x, int[] axes) {
+    return l2Normalize(tf, x, axes, L2_NORM_EPSILON);
+  }
+
+  /**
+   * Normalizes along dimension <code>axis</code> using an L2 norm.
+   *
+   * <p>For a 1-D tensor with <code>axis = 0</code>, computes
+   *
+   * <pre>
+   *       output = x / sqrt(max(sum(x**2), epsilon))
+   * </pre>
+   *
+   * <p>For <code>x</code> with more dimensions, independently normalizes each 1-D slice along
+   * dimension <code>axis</code>.
+   *
+   * @param tf The TensorFlow ops
+   * @param x The operand to normalize
+   * @param axes Dimension(s) along which to normalize.
+   * @param epsilon A lower bound value for the norm. Will use <code>sqrt(epsilon)</code> as the
+   *     divisor if <code>norm &lt; sqrt(epsilon)</code>.
+   * @param <U> The data type for the values.
+   * @return the normalized values of x.
+   */
+  public static <U extends TNumber> Operand<U> l2Normalize(
+      Ops tf, Operand<U> x, int[] axes, float epsilon) {
+    Operand<U> squareSum =
+        tf.reduceSum(tf.math.square(x), tf.constant(axes), ReduceSum.keepDims(Boolean.TRUE));
+    Operand<U> y =
+        tf.math.rsqrt(
+            tf.math.maximum(squareSum, CastHelper.cast(tf, tf.constant(epsilon), x.type())));
+    return tf.math.mul(x, y);
+  }
+}

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/Poisson.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/Poisson.java
@@ -1,0 +1,52 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================*/
+package org.tensorflow.framework.metrics;
+
+import org.tensorflow.Operand;
+import org.tensorflow.framework.losses.Losses;
+import org.tensorflow.framework.metrics.impl.LossMetric;
+import org.tensorflow.framework.metrics.impl.MeanMetricWrapper;
+import org.tensorflow.op.Ops;
+import org.tensorflow.types.family.TNumber;
+
+/**
+ * A metric that computes the poisson loss metric between labels and predictions.
+ *
+ * @param <U> the data type for the predictions.
+ * @param <T> The data type for the metric result.
+ */
+public class Poisson<U extends TNumber, T extends TNumber> extends MeanMetricWrapper<U, T>
+    implements LossMetric<T> {
+
+  /**
+   * Creates a Poisson metric
+   *
+   * @param tf the TensorFlow Ops
+   * @param name the name of this metric, if null then metric name is {@link Class#getSimpleName()}.
+   * @param seed the seed for random number generation. An initializer created with a given seed
+   *     will always produce the same random tensor for a given shape and data type.
+   * @param type the type for the variables and result
+   */
+  public Poisson(Ops tf, String name, long seed, Class<T> type) {
+    super(tf, name, seed, type);
+    setLoss(this);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public <V extends TNumber> Operand<T> call(Operand<V> labels, Operand<T> predictions) {
+    return Losses.poisson(getTF(), labels, predictions);
+  }
+}

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/SparseCategoricalCrossentropy.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/SparseCategoricalCrossentropy.java
@@ -1,0 +1,61 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================*/
+package org.tensorflow.framework.metrics;
+
+import org.tensorflow.Operand;
+import org.tensorflow.framework.losses.Losses;
+import org.tensorflow.framework.metrics.impl.LossMetric;
+import org.tensorflow.framework.metrics.impl.MeanMetricWrapper;
+import org.tensorflow.op.Ops;
+import org.tensorflow.types.family.TNumber;
+
+/**
+ * A metric that computes the sparse categorical cross-entropy loss between true labels and
+ * predicted labels.
+ *
+ * @param <U> the data type for the predictions.
+ * @param <T> The data type for the metric result.
+ */
+public class SparseCategoricalCrossentropy<U extends TNumber, T extends TNumber>
+    extends MeanMetricWrapper<U, T> implements LossMetric<T> {
+
+  private final boolean fromLogits;
+  private final int axis;
+
+  /**
+   * Creates a SparseCategoricalCrossentropy metric
+   *
+   * @param tf the TensorFlow Ops
+   * @param name the name of this metric, if null then metric name is {@link Class#getSimpleName()}.
+   * @param fromLogits Whether to interpret predictions as a tensor of logit values as opposed to a probability distribution.
+   * @param axis The dimension along which the entropy is computed.
+   * @param seed the seed for random number generation. An initializer created with a given seed
+   *     will always produce the same random tensor for a given shape and data type.
+   * @param type the type for the variables and result
+   */
+  public SparseCategoricalCrossentropy(
+      Ops tf, String name, boolean fromLogits, int axis, long seed, Class<T> type) {
+    super(tf, name, seed, type);
+    setLoss(this);
+    this.fromLogits = fromLogits;
+    this.axis = axis;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public <V extends TNumber> Operand<T> call(Operand<V> labels, Operand<T> predictions) {
+    return Losses.sparseCategoricalCrossentropy(getTF(), labels, predictions, fromLogits, axis);
+  }
+}

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/SquaredHinge.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/SquaredHinge.java
@@ -1,0 +1,52 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================*/
+package org.tensorflow.framework.metrics;
+
+import org.tensorflow.Operand;
+import org.tensorflow.framework.losses.Losses;
+import org.tensorflow.framework.metrics.impl.LossMetric;
+import org.tensorflow.framework.metrics.impl.MeanMetricWrapper;
+import org.tensorflow.op.Ops;
+import org.tensorflow.types.family.TNumber;
+
+/**
+ * A metric that computes the squared hinge loss metric between labels and predictions.
+ *
+ * @param <U> the data type for the predictions.
+ * @param <T> The data type for the metric result.
+ */
+public class SquaredHinge<U extends TNumber, T extends TNumber> extends MeanMetricWrapper<U, T>
+    implements LossMetric<T> {
+
+  /**
+   * Creates a SquaredHinge metric
+   *
+   * @param tf the TensorFlow Ops
+   * @param name the name of this metric, if null then metric name is {@link Class#getSimpleName()}.
+   * @param seed the seed for random number generation. An initializer created with a given seed
+   *     will always produce the same random tensor for a given shape and data type.
+   * @param type the type for the variables and result
+   */
+  public SquaredHinge(Ops tf, String name, long seed, Class<T> type) {
+    super(tf, name, seed, type);
+    setLoss(this);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public <V extends TNumber> Operand<T> call(Operand<V> labels, Operand<T> predictions) {
+    return Losses.squaredHinge(getTF(), labels, predictions);
+  }
+}

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/exceptions/NotBroadcastableException.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/exceptions/NotBroadcastableException.java
@@ -1,0 +1,52 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================*/
+package org.tensorflow.framework.metrics.exceptions;
+
+import org.tensorflow.ndarray.Shape;
+
+/**
+ * Exception that indicates that static shapes are not able to broadcast among each other during
+ * arithmetic operations. Static shapes do not have unknown rank or any unknown dimensions {@link
+ * Shape#hasUnknownDimension()}. The term broadcasting describes how TensorFlow treats arrays with
+ * different shapes during arithmetic operations.
+ *
+ * <p>Broadcasting is the process of making arrays to have compatible shapes for arithmetic
+ * operations. Two shapes are compatible if for each dimension pair they are either equal or one of
+ * them is one. When trying to broadcast a Tensor to a shape, it starts with the trailing
+ * dimensions, and works its way forward.
+ *
+ * @see <a href="https://numpy.org/doc/stable/user/basics.broadcasting.html">Numpy Broadcasting</a>
+ */
+public class NotBroadcastableException extends IllegalArgumentException {
+
+  /**
+   * Creates a new NotBroadcastableException exception with the specified detail message
+   *
+   * @param message the detail message.
+   */
+  public NotBroadcastableException(String message) {
+    super(message);
+  }
+
+  /**
+   * Creates a new NotBroadcastableException exception with the specified detail message
+   *
+   * @param message the detail message.
+   * @param cause the cause
+   */
+  public NotBroadcastableException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/impl/LossMetric.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/impl/LossMetric.java
@@ -1,0 +1,36 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================*/
+package org.tensorflow.framework.metrics.impl;
+
+import org.tensorflow.Operand;
+import org.tensorflow.types.family.TNumber;
+
+/**
+ * Interface for Metrics that wrap Loss functions.
+ *
+ * @param <T> The data type of the predictions.
+ */
+public interface LossMetric<T extends TNumber> {
+
+  /**
+   * Calculates the weighted loss between <code>labels</code> and <code>predictions</code>
+   *
+   * @param labels the truth values or labels
+   * @param predictions the predictions
+   * @param <V> The data type of the labels.
+   * @return the loss
+   */
+  <V extends TNumber> Operand<T> call(Operand<V> labels, Operand<T> predictions);
+}

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/impl/MeanMetricWrapper.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/impl/MeanMetricWrapper.java
@@ -1,0 +1,106 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================*/
+package org.tensorflow.framework.metrics.impl;
+
+import org.tensorflow.Operand;
+import org.tensorflow.framework.metrics.Mean;
+import org.tensorflow.framework.metrics.MetricReduction;
+import org.tensorflow.framework.utils.CastHelper;
+import org.tensorflow.op.Op;
+import org.tensorflow.op.Ops;
+import org.tensorflow.types.family.TNumber;
+
+import java.util.List;
+
+/**
+ * A class that bridges a stateless loss function with the {@link Mean} metric using a reduction of
+ * {@link MetricReduction#WEIGHTED_MEAN}.
+ *
+ * <p>The loss function calculates the loss between the <code>labels</code> and <code>predictions
+ * </code> then passes this loss to the {@link Mean} metric to calculate the weighted mean of the
+ * loss over many iterations or epochs
+ *
+ * @param <U> the data type for the predictions.
+ * @param <T> The data type for the metric result
+ */
+public class MeanMetricWrapper<U extends TNumber, T extends TNumber> extends Mean<U, T> {
+
+  /** The loss function interface */
+  protected LossMetric<T> loss;
+
+  /**
+   * Creates a Reducible Metric with a metric reductions of {@link MetricReduction#WEIGHTED_MEAN}
+   *
+   * @param tf the TensorFlow Ops
+   * @param name the name for this metric. If null, name defaults to {@link Class#getSimpleName()}.
+   * @param seed the seed for random number generation. An initializer created with a given seed
+   *     will always produce the same random tensor for a given shape and data type.
+   * @param type the type for the variables and result
+   */
+  protected MeanMetricWrapper(Ops tf, String name, long seed, Class<T> type) {
+    super(tf, name, seed, type);
+  }
+
+  /**
+   * Gets the loss function.
+   *
+   * @return the loss function.
+   */
+  public LossMetric<T> getLoss() {
+    return loss;
+  }
+
+  /**
+   * Sets the Loss function for this wrapper.
+   *
+   * @param loss the loss function.
+   */
+  protected void setLoss(LossMetric<T> loss) {
+    this.loss = loss;
+  }
+
+  /**
+   * Creates Operations that update the state of the mean metric, by calling the loss function and
+   * passing the loss to the Mean metric to calculate the weighted mean of the loss over many
+   * iterations.
+   *
+   * @param labels the truth values or labels
+   * @param predictions the predictions
+   * @param sampleWeights Optional sampleWeights acts as a coefficient for the loss. If a scalar is
+   *     provided, then the loss is simply scaled by the given value. If sampleWeights is a tensor
+   *     of size [batch_size], then the total loss for each sample of the batch is rescaled by the
+   *     corresponding element in the sampleWeights vector. If the shape of sampleWeights is
+   *     [batch_size, d0, .. dN-1] (or can be broadcasted to this shape), then each loss element of
+   *     predictions is scaled by the corresponding value of sampleWeights. (Note on dN-1: all loss
+   *     functions reduce by 1 dimension, usually axis=-1.)
+   * @param <V> the datatype of the labels
+   * @param <S> the data type for sampleWeights
+   * @return a List of control operations that updates the Mean state variables.
+   */
+  public <V extends TNumber, S extends TNumber> List<Op> updateStateList(
+      Operand<V> labels, Operand<U> predictions, Operand<S> sampleWeights) {
+    if (labels == null || predictions == null) {
+      throw new IllegalArgumentException("missing required inputs for labels and predictions");
+    }
+
+    Operand<T> tLabels = CastHelper.cast(getTF(), labels, getResultType());
+    Operand<T> tPredictions = CastHelper.cast(getTF(), predictions, getResultType());
+
+    Operand<T> losses = loss.call(tLabels, tPredictions);
+
+    return super.updateStateList(
+        CastHelper.cast(getTF(), losses, predictions.type()), sampleWeights);
+  }
+}

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/impl/MetricsHelper.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/impl/MetricsHelper.java
@@ -1,0 +1,348 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================*/
+package org.tensorflow.framework.metrics.impl;
+
+import org.tensorflow.Operand;
+import org.tensorflow.framework.metrics.exceptions.NotBroadcastableException;
+import org.tensorflow.ndarray.Shape;
+import org.tensorflow.op.Op;
+import org.tensorflow.op.Ops;
+import org.tensorflow.op.math.Mean;
+import org.tensorflow.types.TBool;
+import org.tensorflow.types.TFloat32;
+import org.tensorflow.types.TFloat64;
+import org.tensorflow.types.TInt32;
+import org.tensorflow.types.family.TIntegral;
+import org.tensorflow.types.family.TNumber;
+import org.tensorflow.types.family.TType;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.tensorflow.framework.losses.impl.LossesHelper.allAxes;
+import static org.tensorflow.framework.utils.CastHelper.cast;
+
+/**
+ * These are helper methods for Metrics and will be module private when Java modularity is applied
+ * to TensorFlow Java. These methods should not be used outside of the metrics packages.
+ */
+public class MetricsHelper {
+  public static final float NEG_INF = -1e10f;
+  private static final String ASSERT_BROADCAST_ERROR_PREFIX =
+      "weights can not be broadcast to values.";
+
+  /**
+   * Asserts that the <code>sampleWeights</code> can be broadcast to the same shape as <code>values
+   * </code>
+   *
+   * <p>In losses and metrics, limited weight broadcasting is supported. Weights must be either
+   * scalar, or the same rank as the target values, with each dimension either 1, or the same as the
+   * corresponding values dimension.
+   *
+   * @param tf the TensorFlow Ops
+   * @param sampleWeights the sample weights.
+   * @param values the values to which weights are applied.
+   * @return <code>Operation</code> with control dependencies to ensure <code>sampleWeight</code>
+   *     can be broadcast to <code>values</code>
+   * @param <U> the type of Operand
+   * @throws NotBroadcastableException If static checks determine <code>sampleWeights</code> has an
+   *     incorrect shape that prohibit broadcasting to <code>values</code>
+   */
+  @SuppressWarnings("unchecked")
+  public static <U extends TNumber> Op assertBroadcastable(
+      Ops tf, Operand<U> sampleWeights, Operand<U> values) {
+
+    // try static check for exact match
+
+    Shape weightsShapeStatic = sampleWeights.shape();
+    int weightsRankStatic = weightsShapeStatic.numDimensions();
+
+    Shape valuesShapeStatic = values.shape();
+    int valuesRankStatic = valuesShapeStatic.numDimensions();
+
+    // if (weightsRankStatic != Shape.UNKNOWN_SIZE && valuesRankStatic != Shape.UNKNOWN_SIZE) {
+    if (!weightsShapeStatic.isUnknown()
+        && !valuesShapeStatic.isUnknown()
+        && !weightsShapeStatic.hasUnknownDimension()
+        && !valuesShapeStatic.hasUnknownDimension()) {
+      if (weightsRankStatic == 0) {
+        return tf.withSubScope("staticScalarCheckSuccess")
+            .withControlDependencies(Collections.EMPTY_LIST)
+            .noOp();
+      }
+      if (weightsRankStatic != valuesRankStatic) {
+        throw new NotBroadcastableException(
+            String.format(
+                "%s values.rank=%d. weights.rank=%d.  values.shape=%s. weights.shape=%s.",
+                ASSERT_BROADCAST_ERROR_PREFIX,
+                valuesRankStatic,
+                weightsRankStatic,
+                valuesShapeStatic.toString(),
+                weightsShapeStatic.toString()));
+      }
+
+      for (int i = 0; i < valuesRankStatic; i++) {
+        if (valuesShapeStatic.size(i) != weightsShapeStatic.size(i)
+            && weightsShapeStatic.size(i) != 1) {
+          throw new NotBroadcastableException(
+              String.format(
+                  "%s Mismatch at dim %d. values.shape=%s weights.shape=%s.",
+                  ASSERT_BROADCAST_ERROR_PREFIX,
+                  i,
+                  valuesShapeStatic.toString(),
+                  weightsShapeStatic.toString()));
+        }
+      }
+      return tf.withSubScope("staticDimsCheckSuccess")
+          .withControlDependencies(Collections.EMPTY_LIST)
+          .noOp();
+    }
+    // Dynamic checks.
+    Operand<TInt32> weightsShape = tf.shape(sampleWeights);
+    Operand<TInt32> weightsRank = tf.rank(sampleWeights);
+    Operand<TInt32> valuesShape = tf.shape(values);
+    Operand<TInt32> valuesRank = tf.rank(values);
+
+    Operand<TBool> isScalar = tf.math.equal(weightsRank, tf.constant(0));
+    List<Operand<?>> data =
+        Arrays.asList(
+            tf.constant(ASSERT_BROADCAST_ERROR_PREFIX),
+            tf.constant("weights.shape="),
+            weightsShape,
+            tf.constant("values.shape="),
+            valuesShape,
+            tf.constant("isScalar="),
+            isScalar);
+
+    // hack to work around the non-lazy select for isValidShape, otherwise validNonscalar fails on a
+    // scalar weight. If select was lazy, that branch wouldn't get executed when iScalar is true.
+    Operand<U> reshapedWeights =
+        tf.select(isScalar, tf.math.mul(sampleWeights, tf.onesLike(values)), sampleWeights);
+    weightsShape = tf.shape(reshapedWeights);
+    weightsRank = tf.rank(reshapedWeights);
+
+    Operand<TBool> validNonscalar =
+        canBroadcastNonscalarShapes(tf, weightsRank, weightsShape, valuesRank, valuesShape);
+
+    Operand<TBool> isValidShape = tf.select(isScalar, isScalar, validNonscalar);
+
+    return tf.withSubScope("broadcastWeights-dynamic").assertThat(isValidShape, data);
+  }
+
+  /**
+   * Gets an operand that tests if the shapes have the same rank and valid dimensions.
+   *
+   * @param tf the TensorFlow Ops
+   * @param weightsRank the operand for the rank of the sample weights
+   * @param weightsShape the operand for the shape of the sample weights
+   * @param valuesRank the operand for the rank of the sample weights
+   * @param valuesShape the operand for the shape of the sample weights
+   * @param <T> the data type for the operands
+   * @return a boolean operand to determine if the Shape is scalar or not.
+   */
+  private static <T extends TNumber> Operand<TBool> canBroadcastNonscalarShapes(
+      Ops tf,
+      Operand<T> weightsRank,
+      Operand<T> weightsShape,
+      Operand<T> valuesRank,
+      Operand<T> valuesShape) {
+    tf = tf.withSubScope("canBroadcastNonscalarShapes");
+    Operand<TBool> isSameRank = tf.math.equal(valuesRank, weightsRank);
+    return tf.select(isSameRank, canBroadcastDims(tf, weightsShape, valuesShape), isSameRank);
+  }
+
+  /**
+   * Gets an operand that tests if the shapes have valid dimensions or not.
+   *
+   * @param tf the TensorFlow Ops
+   * @param weightsShape the operand for the shape of the sample weights
+   * @param valuesShape the operand for the shape of the values
+   * @param <T> the data type for the operands
+   * @return a boolean operand to determine if the shapes have valid dimensions or not.
+   */
+  private static <T extends TNumber> Operand<TBool> canBroadcastDims(
+      Ops tf, Operand<T> weightsShape, Operand<T> valuesShape) {
+    tf = tf.withSubScope("canBroadcastDims");
+    Operand<T> valuesShape2d = tf.expandDims(valuesShape, tf.constant(-1));
+    Operand<T> validDims =
+        tf.concat(Arrays.asList(valuesShape2d, tf.onesLike(valuesShape2d)), tf.constant(1));
+    Operand<T> weightsShape2D = tf.expandDims(weightsShape, tf.constant(-1));
+
+    Operand<T> diffResult = SetsOps.difference(tf, weightsShape2D, validDims);
+    Operand<TInt32> numInvalidDims = tf.size(diffResult);
+    return tf.math.equal(tf.constant(0), numInvalidDims);
+  }
+
+  /**
+   * Broadcast <code>weights</code> to the same shape as <code>values</code>.
+   *
+   * @param tf the TensorFlow ops
+   * @param weights Operand whose shape is broadcastable to <code>values</code>.
+   * @param values Operand of any shape
+   * @param <T> the type of Operands
+   * @return <code>weights</code> broadcast to <code>values</code> shape
+   */
+  public static <T extends TNumber> Operand<T> broadcastWeights(
+      Ops tf, Operand<T> weights, Operand<T> values) {
+
+    Shape weightsShape = weights.shape();
+    Shape valuesShape = values.shape();
+
+    if (!weightsShape.hasUnknownDimension()
+        && !valuesShape.hasUnknownDimension()
+        && weightsShape.isCompatibleWith(valuesShape)) {
+      return weights;
+    }
+
+    Ops ctf =
+        tf.withSubScope("broadcastWeights")
+            .withControlDependencies(
+                Collections.singletonList(assertBroadcastable(tf, weights, tf.onesLike(values))));
+    return ctf.math.mul(weights, tf.onesLike(values));
+  }
+
+  // aliases for mean
+
+  /**
+   * Calculate the mean of the operand, along all axes and <code>keepDims</code> is <code>false
+   * </code>
+   *
+   * @param tf the TensorFlow Ops
+   * @param x the Operand used to calculate the mean
+   * @param <T> the type of the Operand.
+   * @return the mean of the operand
+   */
+  public static <T extends TNumber> Operand<T> mean(Ops tf, Operand<T> x) {
+    return mean(tf, x, null, false);
+  }
+
+  /**
+   * Calculate the mean of the operand, alongside the specified axis with <code>keepDims</code> is
+   * <code>false</code>
+   *
+   * @param tf the TensorFlow Ops
+   * @param x the Operand used to calculate the mean
+   * @param axes Axes to compute the mean.
+   * @param <T> the type of the Operand.
+   * @param <U> the type of the axes.
+   * @return the mean of the operand, along the specified axes.
+   */
+  public static <T extends TNumber, U extends TIntegral> Operand<T> mean(
+      Ops tf, Operand<T> x, Operand<U> axes) {
+    return mean(tf, x, axes, false);
+  }
+
+  /**
+   * Calculates the mean of the operand, along all axes.
+   *
+   * @param tf the TensorFlow Ops
+   * @param x the Operand used to calculate the mean
+   * @param keepDims Indicates whether to keep the dimensions or not. If <code>keepdims</code> is
+   *     <code>false</code>, the rank of the tensor is reduced by 1 for each entry in <code>axes
+   *     </code>. If <code>keepdims</code> is <code>true</code>, the reduced dimensions are retained
+   *     with length 1.
+   * @param <T> the type of the operand
+   * @return the mean of elements of <code>x</code>.
+   */
+  public static <T extends TNumber> Operand<T> mean(
+      Ops tf, Operand<T> x, boolean keepDims) {
+    return mean(tf, x, null, keepDims);
+  }
+
+
+
+  /**
+   * Calculates the mean of the operand, alongside the specified axes.
+   *
+   * @param tf the TensorFlow Ops
+   * @param x the Operand used to calculate the mean
+   * @param axes Axes to compute the mean.
+   * @param keepDims Indicates whether to keep the dimensions or not. If `keepdims` is `false`, the
+   *     * rank of the tensor is reduced by 1 for each entry in `axes`. If `keepdims` is `true`, the
+   *     * reduced dimensions are retained with length 1.
+   * @param <T> the data type of the Operand
+   * @param <U> the data type of the axes
+   * @return the mean of elements of <code>x</code>.
+   */
+
+  public static <T extends TNumber, U extends TIntegral> Operand<T> mean(
+      Ops tf, Operand<T> x, Operand<U> axes, boolean keepDims) {
+    if (axes == null) {
+      axes = (Operand<U>) allAxes(tf, x);
+    }
+    return tf.math.mean(x, axes, Mean.keepDims(keepDims));
+  }
+
+  /**
+   * Calculate the mean of the operand, along all axes and <code>keepDims</code> is <code>false
+   * </code>
+   *
+   * @param tf the TensorFlow Ops
+   * @param x the Operand used to calculate the mean
+   * @return the mean of the operand containing floating point numbers
+   */
+  public static  Operand<TFloat64> booleanMean(Ops tf, Operand<TBool> x) {
+    return booleanMean(tf, x, null, false);
+  }
+
+  /**
+   * Calculate the mean of the operand, alongside the specified axis with <code>keepDims</code> is
+   * <code>false</code>
+   *
+   * @param tf the TensorFlow Ops
+   * @param x the Operand used to calculate the mean
+   * @param axes Axes to compute the mean.
+   * @param <U> the type of the axes.
+   * @return the mean of the operand, along the specified axes, containing floating point numbers
+   */
+  public static <U extends TIntegral> Operand<TFloat64> booleanMean(
+          Ops tf, Operand<TBool> x,Operand<U> axes) {
+    return booleanMean(tf, x, axes, false);
+  }
+
+  /**
+   * Calculates the mean of the boolean operand, alongside all axes.
+   *
+   * @param x the boolean Operand used to calculate the mean
+   * @param keepDims Indicates whether to keep the dimensions or not. If `keepdims` is `false`, the
+   *     * rank of the tensor is reduced by 1 for each entry in `axes`. If `keepdims` is `true`, the
+   *     * reduced dimensions are retained with length 1.
+   * @param <U> the data type of the axes
+   * @return the mean of elements of <code>x</code> containing floating point numbers
+   */
+  public static <U extends TIntegral> Operand<TFloat64> booleanMean(
+          Ops tf, Operand<TBool> x, boolean keepDims) {
+    return booleanMean(tf, x, null, keepDims);
+  }
+
+  /**
+   * Calculates the mean of the boolean operand, alongside the specified axes.
+   *
+   * @param x the boolean Operand used to calculate the mean
+   * @param axes Axes to compute the mean.
+   * @param keepDims Indicates whether to keep the dimensions or not. If `keepdims` is `false`, the
+   *     * rank of the tensor is reduced by 1 for each entry in `axes`. If `keepdims` is `true`, the
+   *     * reduced dimensions are retained with length 1.
+   * @param <U> the data type of the axes
+   * @return the mean of elements of <code>x</code> containing floating point numbers
+   */
+  public static <U extends TIntegral> Operand<TFloat64> booleanMean(
+          Ops tf, Operand<TBool> x, Operand<U> axes, boolean keepDims) {
+    Operand<TFloat64> xf = cast(tf, x, TFloat64.class);
+    return mean(tf, xf, axes, keepDims);
+  }
+
+}

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/impl/Reduce.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/impl/Reduce.java
@@ -1,0 +1,240 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================*/
+package org.tensorflow.framework.metrics.impl;
+
+import org.tensorflow.Operand;
+import org.tensorflow.framework.losses.impl.LossTuple;
+import org.tensorflow.framework.losses.impl.LossesHelper;
+import org.tensorflow.framework.metrics.Metric;
+import org.tensorflow.framework.metrics.MetricReduction;
+import org.tensorflow.framework.utils.CastHelper;
+import org.tensorflow.ndarray.Shape;
+import org.tensorflow.op.Op;
+import org.tensorflow.op.Ops;
+import org.tensorflow.op.core.Variable;
+import org.tensorflow.types.family.TNumber;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Encapsulates metrics that perform a reduce operation on the metric values.
+ *
+ * @param <U> The data type for the metric values
+ * @param <T> The data type for the metric result
+ */
+public abstract class Reduce<U extends TNumber, T extends TNumber> extends Metric<U, T> {
+  public static final String TOTAL = "total";
+  public static final String COUNT = "count";
+  protected final MetricReduction reduction;
+  private final String totalName;
+  private final String countName;
+
+  private final Class<T> resultType;
+  /** the variable that holds the total of the metric values */
+  protected Variable<T> total;
+  /** the variable that holds the count of the metric values.
+   * For {@link MetricReduction#WEIGHTED_MEAN}, this  count may be weighted */
+  protected Variable<T> count;
+
+  /**
+   * Creates a Reducible Metric with a metric reductions of {@link MetricReduction#SUM}
+   *
+   * @param tf the TensorFlow Ops
+   * @param name the name for this metric. If null, name defaults to {@link Class#getSimpleName()}.
+   * @param seed the seed for random number generation. An initializer created with a given seed
+   *     will always produce the same random tensor for a given shape and data type.
+   * @param resultType the type for the variables and result
+   */
+  protected Reduce(Ops tf, String name, long seed, Class<T> resultType) {
+    this(tf, name, MetricReduction.SUM, seed, resultType);
+  }
+
+  /**
+   * @param tf The TensorFlow Ops
+   * @param name the name for this metric. If null, name defaults to {@link Class#getSimpleName()}.
+   * @param reduction The type of metric reduction to apply
+   * @param seed the seed for random number generation. An initializer created with a given seed
+   *     will always produce the same random tensor for a given shape and data type.
+   * @param resultType the type for the variables and result
+   */
+  protected Reduce(Ops tf, String name, MetricReduction reduction, long seed, Class<T> resultType) {
+    super(tf, name, seed);
+    this.reduction = reduction;
+    this.totalName = this.getVariableName(TOTAL);
+    this.countName = this.getVariableName(COUNT);
+    this.resultType = resultType;
+    setupVars();
+  }
+  /** Initializes the Variables */
+  private void setupVars() {
+    if (total == null) {
+      total = getTF().withName(totalName).variable(Shape.scalar(), resultType);
+    }
+    if (reduction == MetricReduction.SUM_OVER_BATCH_SIZE
+        || reduction == MetricReduction.WEIGHTED_MEAN) {
+      if (count == null) {
+        count = getTF().withName(countName).variable(Shape.scalar(), resultType);
+      }
+    }
+  }
+
+  /** {@inheritDoc} */
+  public Op resetStates() {
+    List<Op> controls = new ArrayList<>();
+    if (total != null) {
+      controls.add(
+          getTF().assign(total, CastHelper.cast(getTF(), getTF().constant(0), total.type())));
+    }
+    if (count != null) {
+      controls.add(
+          getTF().assign(count, CastHelper.cast(getTF(), getTF().constant(0), count.type())));
+    }
+    return getTF().withControlDependencies(controls).noOp();
+  }
+
+  /**
+   * Updates the metric variables based on the inputs. At least one input arg required for <code>
+   * values</code>, an optional additional input for the <code>sampleWeights</code>
+   *
+   * @param values the inputs to be passed to update state, this may not be null
+   * @param sampleWeights sample weights to be applied to values, may be null.
+   * @return the result with a control dependency on update state Operands
+   * @throws IllegalArgumentException if values is null
+   */
+  @Override
+  public <V extends TNumber> List<Op> updateStateList(Operand<U> values, Operand<V> sampleWeights) {
+
+    if (values == null) {
+      throw new IllegalArgumentException("values is required.");
+    }
+    List<Op> updateOperations = new ArrayList<>();
+    // cast everything to match the variables
+    Operand<U> lSampleWeights = null;
+    Operand<U> lValues = values;
+
+    if (sampleWeights != null) {
+      lSampleWeights = CastHelper.cast(getTF(), sampleWeights, lValues.type());
+      LossTuple<U> tuple =
+          LossesHelper.squeezeOrExpandDimensions(getTF(), null, lValues, lSampleWeights);
+      lValues = tuple.getTarget();
+      lSampleWeights = tuple.getSampleWeights();
+      try {
+        lSampleWeights = MetricsHelper.broadcastWeights(getTF(), lSampleWeights, lValues);
+      } catch (IllegalArgumentException ex) {
+        // if we get here we have static shapes with either
+        // different ranks or different dimension sizes.
+        // first, reduce the values down to the rank of the samples
+        int valuesRank = lValues.shape().numDimensions();
+        int weightsRank = lSampleWeights.shape().numDimensions();
+        int numAxes = Math.min(0, valuesRank - weightsRank);
+        if (numAxes
+            > 0) { // values rank is greater than weights rank, reduce values to weights rank.
+          int[] axes = new int[numAxes];
+          for (int i = 0; i < numAxes; i++) axes[i] = i + weightsRank;
+          if (reduction == MetricReduction.SUM) {
+            lValues = getTF().reduceSum(lValues, getTF().constant(axes));
+          } else {
+            lValues = getTF().math.mean(lValues, getTF().constant(axes));
+          }
+        }
+      }
+      lValues = getTF().math.mul(lValues, lSampleWeights);
+    }
+
+    Operand<U> weightedValueSum =
+        getTF().reduceSum(lValues, LossesHelper.allAxes(getTF(), lValues));
+    Operand<T> totalUpdate =
+        getTF().assignAdd(total, CastHelper.cast(getTF(), weightedValueSum, total.type()));
+    updateOperations.add(totalUpdate);
+    Operand<T> numValues;
+    if (reduction != MetricReduction.SUM) {
+      switch (reduction) {
+        case SUM_OVER_BATCH_SIZE:
+          numValues =
+              CastHelper.cast(getTF(), getTF().constant(lValues.shape().size()), resultType);
+          break;
+        case WEIGHTED_MEAN:
+          if (lSampleWeights == null) {
+            numValues =
+                CastHelper.cast(getTF(), getTF().constant(lValues.shape().size()), resultType);
+          } else {
+            numValues =
+                CastHelper.cast(
+                    getTF(),
+                    getTF()
+                        .reduceSum(lSampleWeights, LossesHelper.allAxes(getTF(), lSampleWeights)),
+                    resultType);
+          }
+          break;
+        default:
+          throw new UnsupportedOperationException(
+              String.format("reduction [%s] not implemented", reduction));
+      }
+      Operand<T> totalCount = getTF().assignAdd(this.count, numValues);
+
+      updateOperations.add(totalCount);
+    }
+
+    return updateOperations;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Operand<T> result() {
+    Operand<T> fResult;
+
+    switch (this.reduction) {
+      case SUM:
+        fResult = getTF().identity(total);
+        break;
+      case WEIGHTED_MEAN:
+      case SUM_OVER_BATCH_SIZE:
+        fResult = getTF().math.divNoNan(total, CastHelper.cast(getTF(), count, resultType));
+        break;
+      default:
+        throw new UnsupportedOperationException(
+            String.format("reduction [%s] not implemented", reduction));
+    }
+    return fResult;
+  }
+
+  /**
+   * Gets the total variable
+   *
+   * @return the total variable
+   */
+  public Variable<T> getTotal() {
+    return total;
+  }
+
+  /**
+   * Gets the count variable
+   *
+   * @return the count variable
+   */
+  public Variable<T> getCount() {
+    return count;
+  }
+
+  /**
+   * Gets the type for the variables
+   *
+   * @return the type for the variables
+   */
+  public Class<T> getResultType() {
+    return resultType;
+  }
+}

--- a/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/impl/SetsOps.java
+++ b/tensorflow-framework/src/main/java/org/tensorflow/framework/metrics/impl/SetsOps.java
@@ -1,0 +1,146 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================*/
+package org.tensorflow.framework.metrics.impl;
+
+import org.tensorflow.Operand;
+import org.tensorflow.op.Ops;
+import org.tensorflow.op.SparseOps;
+import org.tensorflow.op.sparse.DenseToDenseSetOperation;
+import org.tensorflow.types.family.TNumber;
+
+import static org.tensorflow.framework.utils.CastHelper.cast;
+
+/** Implementation of set operations */
+public class SetsOps {
+
+  /**
+   * Enumeration containing the string operation values to be passed to the TensorFlow Sparse Ops
+   * function {@link SparseOps#denseToDenseSetOperation}
+   */
+  public enum Operation {
+    A_MINUS_B("a-b"),
+    B_MINUS_A("b-a"),
+    INTERSECTION("intersection"),
+    UNION("union");
+
+    private final String setOperation;
+
+    Operation(String setOperation) {
+      this.setOperation = setOperation;
+    }
+
+    /**
+     * Gets the set operation String value used to pass as the stringOperation value to {@link
+     * SparseOps#denseToDenseSetOperation}
+     *
+     * @return the set operation String value
+     */
+    public String getSetOperation() {
+      return setOperation;
+    }
+  }
+
+  /**
+   * Computes set difference of elements in last dimension of <code>a</code> and <code>b</code> with
+   * <code>aMinusB</code> set to true.
+   *
+   * <p>All but the last dimension of <code>a</code> and <code>b</code> must match
+   *
+   * @param tf the TensorFlow Ops
+   * @param a The first operand representing set <code>a</code>
+   * @param b The other operand representing set <code>b</code>
+   * @param <T>the data type for the sets
+   * @return An Operand with the same rank as <code>a</code> and <code>b</code>, and all but the
+   *     last dimension the * same. Elements along the last dimension contain the results of the set
+   *     operation.
+   */
+  public static <T extends TNumber> Operand<T> difference(Ops tf, Operand<T> a, Operand<T> b) {
+    return difference(tf, a, b, true);
+  }
+  /**
+   * Computes set difference of elements in last dimension of <code>a</code> and <code>b</code>.
+   *
+   * <p>All but the last dimension of <code>a</code> and <code>b</code> must match
+   *
+   * @param tf the TensorFlow Ops
+   * @param a The first operand representing set <code>a</code>
+   * @param b The other operand representing set <code>b</code>
+   * @param aMinusB whether to subtract b from a, vs vice versa.
+   * @param <T>the data type for the sets
+   * @return An Operand with the same rank as <code>a</code> and <code>b</code>, and all but the
+   *     last dimension the * same. Elements along the last dimension contain the results of the set
+   *     operation.
+   */
+  public static <T extends TNumber> Operand<T> difference(
+      Ops tf, Operand<T> a, Operand<T> b, boolean aMinusB) {
+    return setOperation(tf, a, b, aMinusB ? Operation.A_MINUS_B : Operation.B_MINUS_A);
+  }
+
+  /**
+   * Computes set union of elements in last dimension of <code>a</code> and <code>b</code>.
+   *
+   * @param tf the TensorFlow Ops
+   * @param a The first operand representing set <code>a</code>
+   * @param b The other operand representing set <code>b</code>
+   * @param <T>the data type for the sets
+   * @return An Operand with the same rank as <code>a</code> and <code>b</code>, and all but the
+   *     last dimension the * same. Elements along the last dimension contain the results of the set
+   *     operation.
+   */
+  public static <T extends TNumber> Operand<T> union(Ops tf, Operand<T> a, Operand<T> b) {
+    return setOperation(tf, a, b, Operation.UNION);
+  }
+
+  /**
+   * Computes set intersection of elements in last dimension of <code>a</code> and <code>b</code>.
+   *
+   * @param tf the TensorFlow Ops
+   * @param a The first operand representing set <code>a</code>
+   * @param b The other operand representing set <code>b</code>
+   * @param <T>the data type for the sets
+   * @return An Operand with the same rank as <code>a</code> and <code>b</code>, and all but the
+   *     last dimension the * same. Elements along the last dimension contain the results of the set
+   *     operation.
+   */
+  public static <T extends TNumber> Operand<T> intersection(Ops tf, Operand<T> a, Operand<T> b) {
+    return setOperation(tf, a, b, Operation.INTERSECTION);
+  }
+
+  /**
+   * Compute set operation of elements in last dimension of <code>a</code> and <code>b</code>.
+   *
+   * @param tf the TensorFlow Ops
+   * @param a The first set operation operand
+   * @param b The other et operation operand
+   * @param setOperation The set operation to perform, {@link Operation}.
+   * @param <T> the data type for the sets
+   * @return An Operand with the same rank as <code>a</code> and <code>b</code>, and all but the
+   *     last dimension the same. Elements along the last dimension contain the results of the set
+   *     operation.
+   */
+  public static <T extends TNumber> Operand<T> setOperation(
+      Ops tf, Operand<T> a, Operand<T> b, Operation setOperation) {
+
+    DenseToDenseSetOperation<T> setOperationResult =
+        tf.sparse.denseToDenseSetOperation(
+            a, b, setOperation.getSetOperation(), DenseToDenseSetOperation.validateIndices(true));
+
+    return tf.sparse.sparseToDense(
+        setOperationResult.resultIndices(),
+        setOperationResult.resultShape(),
+        setOperationResult.resultValues(),
+        cast(tf, tf.constant(0), a.type()));
+  }
+}

--- a/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/BinaryCrossentropyTest.java
+++ b/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/BinaryCrossentropyTest.java
@@ -1,0 +1,151 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================*/
+package org.tensorflow.framework.metrics;
+
+import org.junit.jupiter.api.Test;
+import org.tensorflow.Operand;
+import org.tensorflow.framework.utils.TestSession;
+import org.tensorflow.ndarray.Shape;
+import org.tensorflow.op.Op;
+import org.tensorflow.op.Ops;
+import org.tensorflow.op.core.Variable;
+import org.tensorflow.types.TFloat32;
+import org.tensorflow.types.TFloat64;
+import org.tensorflow.types.TInt32;
+
+class BinaryCrossentropyTest {
+  private final TestSession.Mode tfMode = TestSession.Mode.GRAPH;
+
+  @Test
+  public void testUnweighted() {
+    try (TestSession session = TestSession.createTestSession(tfMode)) {
+      Ops tf = session.getTF();
+      BinaryCrossentropy<TFloat32, TFloat64> instance =
+          new BinaryCrossentropy<>(tf, "BCE_testUnweighted", false, 0, 1001L, TFloat64.class);
+      session.run(instance.resetStates());
+      float[] trueArray = {1, 0, 1, 0};
+      float[] predictionArray = {1, 1, 1, 0};
+      Operand<TFloat32> labels = tf.reshape(tf.constant(trueArray), tf.constant(Shape.of(2, 2)));
+      Operand<TFloat32> yPrediction =
+          tf.reshape(tf.constant(predictionArray), tf.constant(Shape.of(2, 2)));
+      Op op = instance.updateState(labels, yPrediction, null);
+      session.run(op);
+      Variable<TFloat64> total = instance.getTotal();
+      Variable<TFloat64> count = instance.getCount();
+      Operand<TFloat64> result = instance.result();
+      session.evaluate(7.71247434F, total);
+      session.evaluate(2, count);
+      session.evaluate(3.85623717F, result);
+    }
+  }
+
+  @Test
+  public void testUnweightedLogits() {
+    try (TestSession session = TestSession.createTestSession(tfMode)) {
+      Ops tf = session.getTF();
+      BinaryCrossentropy<TFloat64, TFloat64> instance =
+          new BinaryCrossentropy<>(tf, "BCE_testUnweightedLogits", true, 0, 1001L, TFloat64.class);
+      session.run(instance.resetStates());
+      float[] trueArray = {1, 0, 1, 0, 1, 1};
+      double[] logitsArray = {100.0, -100.0, 100.0, 100.0, 100.0, -100.0};
+      Operand<TFloat32> labels = tf.reshape(tf.constant(trueArray), tf.constant(Shape.of(2, 3)));
+      Operand<TFloat64> logits = tf.reshape(tf.constant(logitsArray), tf.constant(Shape.of(2, 3)));
+      Op op = instance.updateState(labels, logits, null);
+      session.run(op);
+      Variable<TFloat64> total = instance.getTotal();
+      Variable<TFloat64> count = instance.getCount();
+      Operand<TFloat64> result = instance.result();
+      session.evaluate(66.66667, total);
+      session.evaluate(2, count);
+      session.evaluate(33.333332, result);
+    }
+  }
+
+  @Test
+  public void testWeighted() {
+    try (TestSession session = TestSession.createTestSession(tfMode)) {
+      Ops tf = session.getTF();
+      BinaryCrossentropy<TFloat32, TFloat32> instance =
+          new BinaryCrossentropy<>(tf, "BCE_testWeighted", false, 0, 1001L, TFloat32.class);
+      session.run(instance.resetStates());
+      int[] trueArray = {1, 0, 1, 0};
+      float[] predictionArray = {1, 1, 1, 0};
+      Operand<TInt32> labels = tf.reshape(tf.constant(trueArray), tf.constant(Shape.of(2, 2)));
+      Operand<TFloat32> yPrediction =
+          tf.reshape(tf.constant(predictionArray), tf.constant(Shape.of(2, 2)));
+      Operand<TFloat32> sampleWeight = tf.constant(new float[] {1.5f, 2.f});
+      Op op = instance.updateState(labels, yPrediction, sampleWeight);
+      session.run(op);
+
+      Variable<TFloat32> total = instance.getTotal();
+      Variable<TFloat32> count = instance.getCount();
+      Operand<TFloat32> result = instance.result();
+      session.evaluate(11.499929f, total);
+      session.evaluate(3.5f, count);
+      session.evaluate(3.285694f, result);
+    }
+  }
+
+  @Test
+  public void testWeightedLogits() {
+    try (TestSession session = TestSession.createTestSession(tfMode)) {
+      Ops tf = session.getTF();
+      BinaryCrossentropy<TFloat64, TFloat64> instance =
+          new BinaryCrossentropy<>(tf, "BCE_testWeightedLogits", true, 0, 1001L, TFloat64.class);
+      session.run(instance.resetStates());
+      float[] trueArray = {1, 0, 1, 0, 1, 1};
+      double[] logitsArray = {100.0, -100.0, 100.0, 100.0, 100.0, -100.0};
+      Operand<TFloat32> labels = tf.reshape(tf.constant(trueArray), tf.constant(Shape.of(2, 3)));
+      Operand<TFloat64> logits = tf.reshape(tf.constant(logitsArray), tf.constant(Shape.of(2, 3)));
+      Operand<TFloat64> sampleWeight = tf.constant(new double[] {2, 2.5});
+
+      Op op = instance.updateState(labels, logits, sampleWeight);
+      session.run(op);
+
+      Variable<TFloat64> total = instance.getTotal();
+      Variable<TFloat64> count = instance.getCount();
+      Operand<TFloat64> result = instance.result();
+      session.evaluate(166.66666, total);
+      session.evaluate(4.5, count);
+      session.evaluate(37.037033, result);
+    }
+  }
+
+  @Test
+  public void testLabelSmoothing() {
+    try (TestSession session = TestSession.createTestSession(tfMode)) {
+      Ops tf = session.getTF();
+      float labelSmoothing = 0.1F;
+      BinaryCrossentropy<TFloat64, TFloat64> instance =
+          new BinaryCrossentropy<>(
+              tf, "BCE_testWeightedLabS", true, labelSmoothing, 1001L, TFloat64.class);
+      session.run(instance.resetStates());
+      float[] trueArray = {1, 0, 1};
+      double[] logitsArray = {100., -100., -100.};
+      Operand<TFloat32> labels = tf.constant(trueArray);
+      Operand<TFloat64> logits = tf.constant(logitsArray);
+
+      Op op = instance.updateState(labels, logits, null);
+      session.run(op);
+      Variable<TFloat64> total = instance.getTotal();
+      Variable<TFloat64> count = instance.getCount();
+      Operand<TFloat64> result = instance.result();
+
+      session.evaluate(35, total);
+      session.evaluate(1, count);
+      session.evaluate(35, result);
+    }
+  }
+}

--- a/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/CategoricalCrossentropyTest.java
+++ b/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/CategoricalCrossentropyTest.java
@@ -1,0 +1,151 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================*/
+package org.tensorflow.framework.metrics;
+
+import org.junit.jupiter.api.Test;
+import org.tensorflow.Operand;
+import org.tensorflow.framework.utils.TestSession;
+import org.tensorflow.ndarray.Shape;
+import org.tensorflow.op.Op;
+import org.tensorflow.op.Ops;
+import org.tensorflow.op.core.Variable;
+import org.tensorflow.types.TFloat64;
+import org.tensorflow.types.TInt32;
+
+class CategoricalCrossentropyTest {
+  private final TestSession.Mode tfMode = TestSession.Mode.GRAPH;
+
+  @Test
+  public void testUnweighted() {
+    try (TestSession session = TestSession.createTestSession(tfMode)) {
+      Ops tf = session.getTF();
+      CategoricalCrossentropy<TFloat64, TFloat64> instance =
+          new CategoricalCrossentropy<>(
+              tf, "CCE_testUnweighted", false, 0, -1, 1001L, TFloat64.class);
+      session.run(instance.resetStates());
+      int[] trueArray = {0, 1, 0, 0, 0, 1};
+      double[] predArray = {0.05, 0.95, 0, 0.1, 0.8, 0.1};
+      Operand<TInt32> labels = tf.reshape(tf.constant(trueArray), tf.constant(Shape.of(2, 3)));
+      Operand<TFloat64> predictions =
+          tf.reshape(tf.constant(predArray), tf.constant(Shape.of(2, 3)));
+      Op op = instance.updateState(labels, predictions, null);
+      session.run(op);
+      Variable<TFloat64> total = instance.getTotal();
+      Variable<TFloat64> count = instance.getCount();
+      Operand<TFloat64> result = instance.result();
+      session.evaluate(2.3538785, total);
+      session.evaluate(2, count);
+      session.evaluate(1.1769392, result);
+    }
+  }
+
+  @Test
+  public void testUnweightedLogits() {
+    try (TestSession session = TestSession.createTestSession(tfMode)) {
+      Ops tf = session.getTF();
+      CategoricalCrossentropy<TFloat64, TFloat64> instance =
+          new CategoricalCrossentropy<>(
+              tf, "CCE_testUnweightedLogits", true, 0, -1, 1001L, TFloat64.class);
+      session.run(instance.resetStates());
+      int[] trueArray = {0, 1, 0, 0, 0, 1};
+      double[] predArray = {1, 9, 0, 1, 8, 1};
+      Operand<TInt32> labels = tf.reshape(tf.constant(trueArray), tf.constant(Shape.of(2, 3)));
+      Operand<TFloat64> predictions =
+          tf.reshape(tf.constant(predArray), tf.constant(Shape.of(2, 3)));
+      Op op = instance.updateState(labels, predictions, null);
+      session.run(op);
+      Variable<TFloat64> total = instance.getTotal();
+      Variable<TFloat64> count = instance.getCount();
+      Operand<TFloat64> result = instance.result();
+      session.evaluate(7.0022807, total);
+      session.evaluate(2, count);
+      session.evaluate(3.5011404, result);
+    }
+  }
+
+  @Test
+  public void testWeighted() {
+    try (TestSession session = TestSession.createTestSession(tfMode)) {
+      Ops tf = session.getTF();
+      CategoricalCrossentropy<TFloat64, TFloat64> instance =
+          new CategoricalCrossentropy<>(
+              tf, "CCE_testWeighted", false, 0, -1, 1001L, TFloat64.class);
+      session.run(instance.resetStates());
+      int[] trueArray = {0, 1, 0, 0, 0, 1};
+      double[] predArray = {0.05f, 0.95f, 0f, 0.1f, 0.8f, 0.1f};
+      Operand<TInt32> labels = tf.reshape(tf.constant(trueArray), tf.constant(Shape.of(2, 3)));
+      Operand<TFloat64> predictions =
+          tf.reshape(tf.constant(predArray), tf.constant(Shape.of(2, 3)));
+      Operand<TFloat64> sampleWeight = tf.constant(new double[] {1.5f, 2.});
+      Op op = instance.updateState(labels, predictions, sampleWeight);
+      session.run(op);
+      Variable<TFloat64> total = instance.getTotal();
+      Variable<TFloat64> count = instance.getCount();
+      Operand<TFloat64> result = instance.result();
+      session.evaluate(4.6821095, total);
+      session.evaluate(3.5, count);
+      session.evaluate(1.3377455, result);
+    }
+  }
+
+  @Test
+  public void testWeightedLogits() {
+    try (TestSession session = TestSession.createTestSession(tfMode)) {
+      Ops tf = session.getTF();
+      CategoricalCrossentropy<TFloat64, TFloat64> instance =
+          new CategoricalCrossentropy<>(tf, "CCE_testWeighted", true, 0, -1, 1001L, TFloat64.class);
+      session.run(instance.resetStates());
+      int[] trueArray = {0, 1, 0, 0, 0, 1};
+      double[] predArray = {1, 9, 0, 1, 8, 1};
+      Operand<TInt32> labels = tf.reshape(tf.constant(trueArray), tf.constant(Shape.of(2, 3)));
+      Operand<TFloat64> predictions =
+          tf.reshape(tf.constant(predArray), tf.constant(Shape.of(2, 3)));
+      Operand<TFloat64> sampleWeight = tf.constant(new double[] {1.5, 2.f});
+      Op op = instance.updateState(labels, predictions, sampleWeight);
+      session.run(op);
+      Variable<TFloat64> total = instance.getTotal();
+      Variable<TFloat64> count = instance.getCount();
+      Operand<TFloat64> result = instance.result();
+      session.evaluate(14.004333, total);
+      session.evaluate(3.5, count);
+      session.evaluate(4.0012328, result);
+    }
+  }
+
+  @Test
+  public void testLabelSmoothing() {
+    try (TestSession session = TestSession.createTestSession(tfMode)) {
+      Ops tf = session.getTF();
+      float labelSmoothing = 0.1F;
+      CategoricalCrossentropy<TFloat64, TFloat64> instance =
+          new CategoricalCrossentropy<>(
+              tf, "CCE_testWeighted", true, labelSmoothing, -1, 1001L, TFloat64.class);
+      session.run(instance.resetStates());
+      int[] trueArray = {0, 1, 0, 0, 0, 1};
+      double[] predArray = {1, 9, 0, 1, 8, 1};
+      Operand<TInt32> labels = tf.reshape(tf.constant(trueArray), tf.constant(Shape.of(2, 3)));
+      Operand<TFloat64> predictions =
+          tf.reshape(tf.constant(predArray), tf.constant(Shape.of(2, 3)));
+      Op op = instance.updateState(labels, predictions, null);
+      session.run(op);
+      Variable<TFloat64> total = instance.getTotal();
+      Variable<TFloat64> count = instance.getCount();
+      Operand<TFloat64> result = instance.result();
+      session.evaluate(7.3356137, total);
+      session.evaluate(2, count);
+      session.evaluate(3.6678069, result);
+    }
+  }
+}

--- a/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/CategoricalHingeTest.java
+++ b/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/CategoricalHingeTest.java
@@ -1,0 +1,97 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================*/
+package org.tensorflow.framework.metrics;
+
+import org.junit.jupiter.api.Test;
+import org.tensorflow.Operand;
+import org.tensorflow.framework.utils.TestSession;
+import org.tensorflow.ndarray.Shape;
+import org.tensorflow.op.Op;
+import org.tensorflow.op.Ops;
+import org.tensorflow.op.core.Variable;
+import org.tensorflow.types.TFloat64;
+import org.tensorflow.types.TInt32;
+
+class CategoricalHingeTest {
+  private final TestSession.Mode tfMode = TestSession.Mode.GRAPH;
+
+  @Test
+  public void testUnweighted() {
+    try (TestSession session = TestSession.createTestSession(tfMode)) {
+      Ops tf = session.getTF();
+      CategoricalHinge<TFloat64, TFloat64> instance =
+          new CategoricalHinge<>(tf, "CH_testUnweighted", 1001L, TFloat64.class);
+      session.run(instance.resetStates());
+      int[] trueArray = {
+        0, 1, 0, 1, 0,
+        0, 0, 1, 1, 1,
+        1, 1, 1, 1, 0,
+        0, 0, 0, 0, 1
+      };
+      double[] predArray = {
+        0, 0, 1, 1, 0,
+        1, 1, 1, 1, 1,
+        0, 1, 0, 1, 0,
+        1, 1, 1, 1, 1
+      };
+      Operand<TInt32> labels = tf.reshape(tf.constant(trueArray), tf.constant(Shape.of(4, 5)));
+      Operand<TFloat64> predictions =
+          tf.reshape(tf.constant(predArray), tf.constant(Shape.of(4, 5)));
+      Op op = instance.updateState(labels, predictions, null);
+      session.run(op);
+      Variable<TFloat64> total = instance.getTotal();
+      Variable<TFloat64> count = instance.getCount();
+      Operand<TFloat64> result = instance.result();
+      session.evaluate(2., total);
+      session.evaluate(4, count);
+      session.evaluate(0.5, result);
+    }
+  }
+
+  @Test
+  public void testWeighted() {
+    try (TestSession session = TestSession.createTestSession(tfMode)) {
+      Ops tf = session.getTF();
+      CategoricalHinge<TFloat64, TFloat64> instance =
+          new CategoricalHinge<>(tf, "CH_testWeighted", 1001L, TFloat64.class);
+      session.run(instance.resetStates());
+      int[] trueArray = {
+        0, 1, 0, 1, 0,
+        0, 0, 1, 1, 1,
+        1, 1, 1, 1, 0,
+        0, 0, 0, 0, 1
+      };
+      double[] predArray = {
+        0, 0, 1, 1, 0,
+        1, 1, 1, 1, 1,
+        0, 1, 0, 1, 0,
+        1, 1, 1, 1, 1
+      };
+      Operand<TInt32> labels = tf.reshape(tf.constant(trueArray), tf.constant(Shape.of(4, 5)));
+      Operand<TFloat64> predictions =
+          tf.reshape(tf.constant(predArray), tf.constant(Shape.of(4, 5)));
+
+      Operand<TFloat64> sampleWeight = tf.constant(new double[] {1., 1.5, 2., 2.5});
+      Op op = instance.updateState(labels, predictions, sampleWeight);
+      session.run(op);
+      Variable<TFloat64> total = instance.getTotal();
+      Variable<TFloat64> count = instance.getCount();
+      Operand<TFloat64> result = instance.result();
+      session.evaluate(3.5F, total);
+      session.evaluate(7, count);
+      session.evaluate(0.5, result);
+    }
+  }
+}

--- a/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/CosineSimilarityTest.java
+++ b/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/CosineSimilarityTest.java
@@ -1,0 +1,101 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================*/
+package org.tensorflow.framework.metrics;
+
+import org.junit.jupiter.api.Test;
+import org.tensorflow.Operand;
+import org.tensorflow.framework.utils.TestSession;
+import org.tensorflow.ndarray.Shape;
+import org.tensorflow.op.Op;
+import org.tensorflow.op.Ops;
+import org.tensorflow.op.core.Variable;
+import org.tensorflow.types.TFloat32;
+import org.tensorflow.types.TInt32;
+
+class CosineSimilarityTest {
+  private final TestSession.Mode tfMode = TestSession.Mode.GRAPH;
+
+  @Test
+  public void testUnweighted() {
+    try (TestSession session = TestSession.createTestSession(tfMode)) {
+      Ops tf = session.getTF();
+      CosineSimilarity<TFloat32, TFloat32> instance =
+          new CosineSimilarity<>(tf, "CS_testUnweighted", 1001L, TFloat32.class);
+      session.run(instance.resetStates());
+      int[] trueArray = {1, 9, 2, -5, -2, 6};
+      float[] predArray = {4, 8, 12, 8, 1, 3};
+      Operand<TInt32> labels = tf.reshape(tf.constant(trueArray), tf.constant(Shape.of(2, 3)));
+      Operand<TFloat32> predictions =
+          tf.reshape(tf.constant(predArray), tf.constant(Shape.of(2, 3)));
+      Op op = instance.updateState(labels, predictions, null);
+      session.run(op);
+      Variable<TFloat32> total = instance.getTotal();
+      Variable<TFloat32> count = instance.getCount();
+      Operand<TFloat32> result = instance.result();
+      session.evaluate(0.3744381F, total);
+      session.evaluate(2, count);
+      session.evaluate(0.18721905F, result);
+    }
+  }
+
+  @Test
+  public void testWeighted() {
+    try (TestSession session = TestSession.createTestSession(tfMode)) {
+      Ops tf = session.getTF();
+      CosineSimilarity<TFloat32, TFloat32> instance =
+          new CosineSimilarity<>(tf, "CS_testWeighted", 1001L, TFloat32.class);
+      session.run(instance.resetStates());
+      int[] trueArray = {1, 9, 2, -5, -2, 6};
+      float[] predArray = {4, 8, 12, 8, 1, 3};
+      Operand<TInt32> labels = tf.reshape(tf.constant(trueArray), tf.constant(Shape.of(2, 3)));
+      Operand<TFloat32> predictions =
+          tf.reshape(tf.constant(predArray), tf.constant(Shape.of(2, 3)));
+
+      Operand<TFloat32> sampleWeight = tf.constant(new float[] {1.2f, 3.4f});
+      Op op = instance.updateState(labels, predictions, sampleWeight);
+      session.run(op);
+      Variable<TFloat32> total = instance.getTotal();
+      Variable<TFloat32> count = instance.getCount();
+      Operand<TFloat32> result = instance.result();
+      session.evaluate(-0.3119840621948241F, total);
+      session.evaluate(4.6, count);
+      session.evaluate(-0.06782262221626612F, result);
+    }
+  }
+
+  @Test
+  public void test_axis() {
+    try (TestSession session = TestSession.createTestSession(tfMode)) {
+      Ops tf = session.getTF();
+      int axis = 1;
+      CosineSimilarity<TFloat32, TFloat32> instance =
+          new CosineSimilarity<>(tf, "CS_testWeighted", axis, 1001L, TFloat32.class);
+      session.run(instance.resetStates());
+      int[] trueArray = {1, 9, 2, -5, -2, 6};
+      float[] predArray = {4, 8, 12, 8, 1, 3};
+      Operand<TInt32> labels = tf.reshape(tf.constant(trueArray), tf.constant(Shape.of(2, 3)));
+      Operand<TFloat32> predictions =
+          tf.reshape(tf.constant(predArray), tf.constant(Shape.of(2, 3)));
+      Op op = instance.updateState(labels, predictions, null);
+      session.run(op);
+      Variable<TFloat32> total = instance.getTotal();
+      Variable<TFloat32> count = instance.getCount();
+      Operand<TFloat32> result = instance.result();
+      session.evaluate(0.3744381F, total);
+      session.evaluate(2, count);
+      session.evaluate(0.18721905F, result);
+    }
+  }
+}

--- a/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/HingeTest.java
+++ b/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/HingeTest.java
@@ -1,0 +1,84 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================*/
+package org.tensorflow.framework.metrics;
+
+import org.junit.jupiter.api.Test;
+import org.tensorflow.Operand;
+import org.tensorflow.framework.utils.TestSession;
+import org.tensorflow.ndarray.Shape;
+import org.tensorflow.op.Op;
+import org.tensorflow.op.Ops;
+import org.tensorflow.op.core.Variable;
+import org.tensorflow.types.TFloat32;
+import org.tensorflow.types.TFloat64;
+import org.tensorflow.types.TInt32;
+
+class HingeTest {
+  private final TestSession.Mode tfMode = TestSession.Mode.GRAPH;
+
+  @Test
+  public void testUnweighted() {
+    try (TestSession session = TestSession.createTestSession(tfMode)) {
+      Ops tf = session.getTF();
+      Hinge<TFloat64, TFloat64> instance =
+          new Hinge<>(tf, "Hinge_testUnweighted", 1001L, TFloat64.class);
+      session.run(instance.resetStates());
+      int[] trueArray = {0, 1, 0, 1, 0, 0, 1, 1};
+      double[] predArray = {-0.3, 0.2, -0.1, 1.6, -0.25, -1., 0.5, 0.6};
+      Operand<TInt32> labels = tf.reshape(tf.constant(trueArray), tf.constant(Shape.of(2, 4)));
+      Operand<TFloat64> predictions =
+          tf.reshape(tf.constant(predArray), tf.constant(Shape.of(2, 4)));
+      Op op = instance.updateState(labels, predictions, null);
+      session.run(op);
+      Variable<TFloat64> total = instance.getTotal();
+      Variable<TFloat64> count = instance.getCount();
+      Operand<TFloat64> result = instance.result();
+      session.evaluate(1.0125, total);
+      session.evaluate(2, count);
+      session.evaluate(.5062500, result);
+    }
+  }
+
+  @Test
+  public void testWeighted() {
+    try (TestSession session = TestSession.createTestSession(tfMode)) {
+      Ops tf = session.getTF();
+      Hinge<TFloat32, TFloat64> instance =
+          new Hinge<>(tf, "Hinge_testWeighted", 1001L, TFloat64.class);
+      session.run(instance.resetStates());
+      int[] trueArray = {
+        -1, 1, -1, 1,
+        -1, -1, 1, 1
+      };
+      float[] predArray = {
+        -0.3f, 0.2f, -0.1f, 1.6f,
+        -0.25f, -1.f, 0.5f, 0.6f
+      };
+      Operand<TInt32> labels = tf.reshape(tf.constant(trueArray), tf.constant(Shape.of(2, 4)));
+      Operand<TFloat32> predictions =
+          tf.reshape(tf.constant(predArray), tf.constant(Shape.of(2, 4)));
+
+      Operand<TFloat64> sampleWeight = tf.constant(new double[] {1.5, 2.});
+      Op op = instance.updateState(labels, predictions, sampleWeight);
+      session.run(op);
+      Variable<TFloat64> total = instance.getTotal();
+      Variable<TFloat64> count = instance.getCount();
+      Operand<TFloat64> result = instance.result();
+      session.evaluate(1.7250f, total);
+      session.evaluate(3.5, count);
+      session.evaluate(.49285714f, result);
+    }
+  }
+}

--- a/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/KLDivergenceTest.java
+++ b/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/KLDivergenceTest.java
@@ -1,0 +1,83 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================*/
+package org.tensorflow.framework.metrics;
+
+import org.junit.jupiter.api.Test;
+import org.tensorflow.Operand;
+import org.tensorflow.framework.utils.TestSession;
+import org.tensorflow.ndarray.Shape;
+import org.tensorflow.op.Op;
+import org.tensorflow.op.Ops;
+import org.tensorflow.op.core.Variable;
+import org.tensorflow.types.TFloat32;
+import org.tensorflow.types.TFloat64;
+
+class KLDivergenceTest {
+  private final TestSession.Mode tfMode = TestSession.Mode.GRAPH;
+
+  @Test
+  public void testUnweighted() {
+    try (TestSession session = TestSession.createTestSession(tfMode)) {
+      Ops tf = session.getTF();
+      KLDivergence<TFloat32, TFloat64> instance =
+          new KLDivergence<>(tf, "KLD_testUnweighted", 1001L, TFloat64.class);
+      session.run(instance.resetStates());
+      float[][] trueArray = {{.5f, .8f, .12f}, {.7f, .43f, .8f}};
+      float[][] predArray = {{.4f, .9f, .12f}, {.36f, .3f, .4f}};
+      Operand<TFloat32> labels = tf.constant(trueArray);
+      Operand<TFloat32> predictions = tf.constant(predArray);
+
+      Op op = instance.updateState(labels, predictions, null);
+      session.run(op);
+      Variable<TFloat64> total = instance.getTotal();
+      Variable<TFloat64> count = instance.getCount();
+      Operand<TFloat64> result = instance.result();
+      session.evaluate(1.1921477, total);
+      session.evaluate(2, count);
+      session.evaluate(0.5960738, result);
+    }
+  }
+
+  @Test
+  public void testWeighted() {
+    try (TestSession session = TestSession.createTestSession(tfMode)) {
+      Ops tf = session.getTF();
+      KLDivergence<TFloat32, TFloat64> instance =
+          new KLDivergence<>(tf, "KLD_testWeighted", 1001L, TFloat64.class);
+      session.run(instance.resetStates());
+      float[] trueArray = {
+        .5f, .8f, .12f,
+        .7f, .43f, .8f
+      };
+      float[] predArray = {
+        .4f, .9f, .12f,
+        .36f, .3f, .4f
+      };
+      Operand<TFloat32> labels = tf.reshape(tf.constant(trueArray), tf.constant(Shape.of(2, 3)));
+      Operand<TFloat32> predictions =
+          tf.reshape(tf.constant(predArray), tf.constant(Shape.of(2, 3)));
+
+      Operand<TFloat64> sampleWeight = tf.constant(new double[][] {{1.2}, {3.4}});
+      Op op = instance.updateState(labels, predictions, sampleWeight);
+      session.run(op);
+      Variable<TFloat64> total = instance.getTotal();
+      Variable<TFloat64> count = instance.getCount();
+      Operand<TFloat64> result = instance.result();
+      session.evaluate(4.015142, total);
+      session.evaluate(4.6, count);
+      session.evaluate(0.872857, result);
+    }
+  }
+}

--- a/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/LogCoshErrorTest.java
+++ b/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/LogCoshErrorTest.java
@@ -1,0 +1,80 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================*/
+package org.tensorflow.framework.metrics;
+
+import org.junit.jupiter.api.Test;
+import org.tensorflow.Operand;
+import org.tensorflow.framework.utils.TestSession;
+import org.tensorflow.ndarray.Shape;
+import org.tensorflow.op.Op;
+import org.tensorflow.op.Ops;
+import org.tensorflow.op.core.Variable;
+import org.tensorflow.types.TFloat32;
+import org.tensorflow.types.TFloat64;
+import org.tensorflow.types.TInt32;
+
+class LogCoshErrorTest {
+  private final TestSession.Mode tfMode = TestSession.Mode.GRAPH;
+
+  @Test
+  public void testUnweighted() {
+    try (TestSession session = TestSession.createTestSession(tfMode)) {
+      Ops tf = session.getTF();
+      LogCoshError<TFloat32, TFloat64> instance =
+          new LogCoshError<>(tf, "LogCosh_testUnweighted", 1001L, TFloat64.class);
+      session.run(instance.resetStates());
+      float[] trueArray = {1, 9, 2, -5, -2, 6};
+      float[] predArray = {4, 8, 12, 8, 1, 3};
+      Operand<TFloat32> labels = tf.reshape(tf.constant(trueArray), tf.constant(Shape.of(2, 3)));
+      Operand<TFloat32> predictions =
+          tf.reshape(tf.constant(predArray), tf.constant(Shape.of(2, 3)));
+
+      Op op = instance.updateState(labels, predictions, null);
+      session.run(op);
+      Variable<TFloat64> total = instance.getTotal();
+      Variable<TFloat64> count = instance.getCount();
+      Operand<TFloat64> result = instance.result();
+      session.evaluate(4.829245, result);
+      session.evaluate(9.65849, total);
+      session.evaluate(2, count);
+    }
+  }
+
+  @Test
+  public void testWeighted() {
+    try (TestSession session = TestSession.createTestSession(tfMode)) {
+      Ops tf = session.getTF();
+      LogCoshError<TFloat32, TFloat64> instance =
+          new LogCoshError<>(tf, "LogCosh_testWeighted", 1001L, TFloat64.class);
+      session.run(instance.resetStates());
+      int[] trueArray = {1, 9, 2, -5, -2, 6};
+      float[] predArray = {4, 8, 12, 8, 1, 3};
+      double[][] sampleArray = {{1.2}, {3.4}};
+      Operand<TInt32> labels = tf.reshape(tf.constant(trueArray), tf.constant(Shape.of(2, 3)));
+      Operand<TFloat32> predictions =
+          tf.reshape(tf.constant(predArray), tf.constant(Shape.of(2, 3)));
+      Operand<TFloat64> sampleWeight = tf.constant(sampleArray);
+
+      Op op = instance.updateState(labels, predictions, sampleWeight);
+      session.run(op);
+      Variable<TFloat64> total = instance.getTotal();
+      Variable<TFloat64> count = instance.getCount();
+      Operand<TFloat64> result = instance.result();
+      session.evaluate(5.2178759, result);
+      session.evaluate(24.002228, total);
+      session.evaluate(4.6, count);
+    }
+  }
+}

--- a/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/MeanAbsoluteErrorTest.java
+++ b/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/MeanAbsoluteErrorTest.java
@@ -1,0 +1,116 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================*/
+package org.tensorflow.framework.metrics;
+
+import org.junit.jupiter.api.Test;
+import org.tensorflow.Operand;
+import org.tensorflow.framework.utils.TestSession;
+import org.tensorflow.ndarray.Shape;
+import org.tensorflow.op.Op;
+import org.tensorflow.op.Ops;
+import org.tensorflow.op.core.Variable;
+import org.tensorflow.types.TFloat32;
+import org.tensorflow.types.TFloat64;
+import org.tensorflow.types.TInt32;
+
+class MeanAbsoluteErrorTest {
+  private final TestSession.Mode tfMode = TestSession.Mode.GRAPH;
+
+  @Test
+  public void testUnweighted() {
+    try (TestSession session = TestSession.createTestSession(tfMode)) {
+      Ops tf = session.getTF();
+      MeanAbsoluteError<TFloat32, TFloat64> instance =
+          new MeanAbsoluteError<>(tf, "MAE_testUnweighted", 1001L, TFloat64.class);
+      session.run(instance.resetStates());
+      session.evaluate(0.0f, instance.getTotal());
+      session.evaluate(0f, instance.getCount());
+      session.evaluate(0.f, instance.getCount());
+
+      int[] trueArray = {
+        0, 1, 0, 1, 0,
+        0, 0, 1, 1, 1,
+        1, 1, 1, 1, 0,
+        0, 0, 0, 0, 1
+      };
+      float[] predictionArray = {
+        0, 0, 1, 1, 0,
+        1, 1, 1, 1, 1,
+        0, 1, 0, 1, 0,
+        1, 1, 1, 1, 1
+      };
+      Operand<TInt32> yTrue = tf.reshape(tf.constant(trueArray), tf.constant(Shape.of(4, 5)));
+      Operand<TFloat32> yPrediction =
+          tf.reshape(tf.constant(predictionArray), tf.constant(Shape.of(4, 5)));
+      Op op = instance.updateState(yTrue, yPrediction, null);
+      session.run(op);
+      Variable<TFloat64> total = instance.getTotal();
+      Variable<TFloat64> count = instance.getCount();
+      Operand<TFloat64> result = instance.result();
+      session.evaluate(2.0, total);
+      session.evaluate(4, count);
+      session.evaluate(0.5, result);
+
+      session.run(instance.resetStates());
+      session.evaluate(0.0, instance.getTotal());
+      session.evaluate(0, instance.getCount());
+      session.evaluate(0., instance.getCount());
+    }
+  }
+
+  @Test
+  public void testWeighted() {
+    try (TestSession session = TestSession.createTestSession(tfMode)) {
+      Ops tf = session.getTF();
+      MeanAbsoluteError<TFloat64, TFloat64> instance =
+          new MeanAbsoluteError<>(tf, "MAE_testWeighted", 1001L, TFloat64.class);
+      session.run(instance.resetStates());
+      session.evaluate(0.0, instance.getTotal());
+      session.evaluate(0, instance.getCount());
+      session.evaluate(0., instance.getCount());
+
+      int[] trueArray = {
+        0, 1, 0, 1, 0,
+        0, 0, 1, 1, 1,
+        1, 1, 1, 1, 0,
+        0, 0, 0, 0, 1
+      };
+      double[] predictionArray = {
+        0, 0, 1, 1, 0,
+        1, 1, 1, 1, 1,
+        0, 1, 0, 1, 0,
+        1, 1, 1, 1, 1
+      };
+      Operand<TInt32> yTrue = tf.reshape(tf.constant(trueArray), tf.constant(Shape.of(4, 5)));
+      Operand<TFloat64> yPrediction =
+          tf.reshape(tf.constant(predictionArray), tf.constant(Shape.of(4, 5)));
+
+      Operand<TFloat64> sampleWeight = tf.constant(new double[] {1., 1.5, 2., 2.5});
+      Op op = instance.updateState(yTrue, yPrediction, sampleWeight);
+      session.run(op);
+      Variable<TFloat64> total = instance.getTotal();
+      Variable<TFloat64> count = instance.getCount();
+      Operand<TFloat64> result = instance.result();
+      session.evaluate(3.8, total);
+      session.evaluate(7, count);
+      session.evaluate(0.54285, result);
+
+      session.run(instance.resetStates());
+      session.evaluate(0.0, instance.getTotal());
+      session.evaluate(0, instance.getCount());
+      session.evaluate(0., instance.getCount());
+    }
+  }
+}

--- a/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/MeanAbsolutePercentageErrorTest.java
+++ b/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/MeanAbsolutePercentageErrorTest.java
@@ -1,0 +1,115 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================*/
+package org.tensorflow.framework.metrics;
+
+import org.junit.jupiter.api.Test;
+import org.tensorflow.Operand;
+import org.tensorflow.framework.utils.TestSession;
+import org.tensorflow.ndarray.Shape;
+import org.tensorflow.op.Op;
+import org.tensorflow.op.Ops;
+import org.tensorflow.op.core.Variable;
+import org.tensorflow.types.TFloat32;
+import org.tensorflow.types.TFloat64;
+import org.tensorflow.types.TInt32;
+import org.tensorflow.types.TInt64;
+
+class MeanAbsolutePercentageErrorTest {
+  private final TestSession.Mode tfMode = TestSession.Mode.GRAPH;
+
+  @Test
+  public void testUnweighted() {
+    try (TestSession session = TestSession.createTestSession(tfMode)) {
+      session.setEpsilon(1E-6f);
+      Ops tf = session.getTF();
+      MeanAbsolutePercentageError<TFloat32, TFloat32> instance =
+          new MeanAbsolutePercentageError<>(tf, "MAPE_testUnweighted", 1001L, TFloat32.class);
+      session.run(instance.resetStates());
+      session.evaluate(0.0f, instance.getTotal());
+      session.evaluate(0f, instance.getCount());
+      session.evaluate(0.f, instance.getCount());
+
+      int[] trueArray = {
+        0, 1, 0, 1, 0,
+        0, 0, 1, 1, 1,
+        1, 1, 1, 1, 0,
+        0, 0, 0, 0, 1
+      };
+      float[] predictionArray = {
+        0, 0, 1, 1, 0,
+        1, 1, 1, 1, 1,
+        0, 1, 0, 1, 0,
+        1, 1, 1, 1, 1
+      };
+
+      Operand<TInt32> yTrue = tf.reshape(tf.constant(trueArray), tf.constant(Shape.of(4, 5)));
+      Operand<TFloat32> yPrediction =
+          tf.reshape(tf.constant(predictionArray), tf.constant(Shape.of(4, 5)));
+
+      Op op = instance.updateState(yTrue, yPrediction, null);
+
+      session.run(op);
+
+      Variable<TFloat32> total = instance.getTotal();
+      Variable<TFloat32> count = instance.getCount();
+      Operand<TFloat32> result = instance.result();
+      session.evaluate(1.4E9f, total);
+      session.evaluate(4f, count);
+      session.evaluate(35e7f, result);
+    }
+  }
+
+  @Test
+  public void testWeighted() {
+    try (TestSession session = TestSession.createTestSession(tfMode)) {
+      session.setEpsilon(1E-6f);
+      Ops tf = session.getTF();
+      MeanAbsolutePercentageError<TFloat64, TFloat64> instance =
+          new MeanAbsolutePercentageError<>(tf, "MAPE_testWeighted", 1001L, TFloat64.class);
+      session.run(instance.resetStates());
+      session.evaluate(0.0, instance.getTotal());
+      session.evaluate(0, instance.getCount());
+      session.evaluate(0, instance.getCount());
+
+      long[] trueArray = {
+        0, 1, 0, 1, 0,
+        0, 0, 1, 1, 1,
+        1, 1, 1, 1, 0,
+        0, 0, 0, 0, 1
+      };
+      double[] predictionArray = {
+        0, 0, 1, 1, 0,
+        1, 1, 1, 1, 1,
+        0, 1, 0, 1, 0,
+        1, 1, 1, 1, 1
+      };
+      Operand<TInt64> yTrue = tf.reshape(tf.constant(trueArray), tf.constant(Shape.of(4, 5)));
+      Operand<TFloat64> yPrediction =
+          tf.reshape(tf.constant(predictionArray), tf.constant(Shape.of(4, 5)));
+
+      Operand<TFloat64> sampleWeight = tf.constant(new double[] {1.f, 1.5f, 2.f, 2.5f});
+      Op op = instance.updateState(yTrue, yPrediction, sampleWeight);
+
+      session.run(op);
+
+      Variable<TFloat64> total = instance.getTotal();
+      Variable<TFloat64> count = instance.getCount();
+      Operand<TFloat64> result = instance.result();
+      session.evaluate(2.800000067278928E9, total);
+      session.evaluate(7, count);
+      session.evaluate(4.000000096112754E8, result);
+    }
+  }
+}

--- a/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/MeanSquaredErrorTest.java
+++ b/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/MeanSquaredErrorTest.java
@@ -1,0 +1,107 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================*/
+package org.tensorflow.framework.metrics;
+
+import org.junit.jupiter.api.Test;
+import org.tensorflow.Operand;
+import org.tensorflow.framework.utils.TestSession;
+import org.tensorflow.ndarray.Shape;
+import org.tensorflow.op.Op;
+import org.tensorflow.op.Ops;
+import org.tensorflow.op.core.Variable;
+import org.tensorflow.types.TFloat32;
+import org.tensorflow.types.TFloat64;
+import org.tensorflow.types.TInt32;
+import org.tensorflow.types.TInt64;
+
+class MeanSquaredErrorTest {
+  private final TestSession.Mode tfMode = TestSession.Mode.GRAPH;
+
+  @Test
+  public void testUnweighted() {
+    try (TestSession session = TestSession.createTestSession(tfMode)) {
+      Ops tf = session.getTF();
+      MeanSquaredError<TFloat32, TFloat64> instance =
+          new MeanSquaredError<>(tf, "MSE_testUnweighted", 1001L, TFloat64.class);
+      session.run(instance.resetStates());
+      session.evaluate(0.0, instance.getTotal());
+      session.evaluate(0, instance.getCount());
+      session.evaluate(0., instance.getCount());
+
+      int[] trueArray = {
+        0, 1, 0, 1, 0,
+        0, 0, 1, 1, 1,
+        1, 1, 1, 1, 0,
+        0, 0, 0, 0, 1
+      };
+      float[] predictionArray = {
+        0, 0, 1, 1, 0,
+        1, 1, 1, 1, 1,
+        0, 1, 0, 1, 0,
+        1, 1, 1, 1, 1
+      };
+      Operand<TInt32> yTrue = tf.reshape(tf.constant(trueArray), tf.constant(Shape.of(4, 5)));
+      Operand<TFloat32> yPrediction =
+          tf.reshape(tf.constant(predictionArray), tf.constant(Shape.of(4, 5)));
+      Op op = instance.updateState(yTrue, yPrediction, null);
+      session.run(op);
+      Variable<TFloat64> total = instance.getTotal();
+      Variable<TFloat64> count = instance.getCount();
+      Operand<TFloat64> result = instance.result();
+      session.evaluate(2.0, total);
+      session.evaluate(4, count);
+      session.evaluate(0.5, result);
+    }
+  }
+
+  @Test
+  public void testWeighted() {
+    try (TestSession session = TestSession.createTestSession(tfMode)) {
+      Ops tf = session.getTF();
+      MeanSquaredError<TFloat32, TFloat64> instance =
+          new MeanSquaredError<>(tf, "MSE_testWeighted", 1001L, TFloat64.class);
+      session.run(instance.resetStates());
+      session.evaluate(0.0, instance.getTotal());
+      session.evaluate(0, instance.getCount());
+      session.evaluate(0., instance.getCount());
+
+      long[] trueArray = {
+        0, 1, 0, 1, 0,
+        0, 0, 1, 1, 1,
+        1, 1, 1, 1, 0,
+        0, 0, 0, 0, 1
+      };
+      float[] predictionArray = {
+        0, 0, 1, 1, 0,
+        1, 1, 1, 1, 1,
+        0, 1, 0, 1, 0,
+        1, 1, 1, 1, 1
+      };
+      Operand<TInt64> yTrue = tf.reshape(tf.constant(trueArray), tf.constant(Shape.of(4, 5)));
+      Operand<TFloat32> yPrediction =
+          tf.reshape(tf.constant(predictionArray), tf.constant(Shape.of(4, 5)));
+
+      Operand<TFloat64> sampleWeight = tf.constant(new double[] {1., 1.5, 2., 2.5});
+      Op op = instance.updateState(yTrue, yPrediction, sampleWeight);
+      session.run(op);
+      Variable<TFloat64> total = instance.getTotal();
+      Variable<TFloat64> count = instance.getCount();
+      Operand<TFloat64> result = instance.result();
+      session.evaluate(3.8, total);
+      session.evaluate(7, count);
+      session.evaluate(0.542857, result);
+    }
+  }
+}

--- a/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/MeanSquaredLogarithmicErrorTest.java
+++ b/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/MeanSquaredLogarithmicErrorTest.java
@@ -1,0 +1,106 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================*/
+package org.tensorflow.framework.metrics;
+
+import org.junit.jupiter.api.Test;
+import org.tensorflow.Operand;
+import org.tensorflow.framework.utils.TestSession;
+import org.tensorflow.ndarray.Shape;
+import org.tensorflow.op.Op;
+import org.tensorflow.op.Ops;
+import org.tensorflow.op.core.Variable;
+import org.tensorflow.types.TFloat32;
+import org.tensorflow.types.TFloat64;
+import org.tensorflow.types.TInt32;
+
+class MeanSquaredLogarithmicErrorTest {
+  private final TestSession.Mode tfMode = TestSession.Mode.GRAPH;
+
+  @Test
+  public void testUnweighted() {
+    try (TestSession session = TestSession.createTestSession(tfMode)) {
+      Ops tf = session.getTF();
+      MeanSquaredLogarithmicError<TFloat32, TFloat32> instance =
+          new MeanSquaredLogarithmicError<>(tf, "MSLE_testUnweighted", 1001L, TFloat32.class);
+      session.run(instance.resetStates());
+      session.evaluate(0.0f, instance.getTotal());
+      session.evaluate(0f, instance.getCount());
+      session.evaluate(0.f, instance.getCount());
+
+      int[] trueArray = {
+        0, 1, 0, 1, 0,
+        0, 0, 1, 1, 1,
+        1, 1, 1, 1, 0,
+        0, 0, 0, 0, 1
+      };
+      float[] predictionArray = {
+        0, 0, 1, 1, 0,
+        1, 1, 1, 1, 1,
+        0, 1, 0, 1, 0,
+        1, 1, 1, 1, 1
+      };
+      Operand<TInt32> yTrue = tf.reshape(tf.constant(trueArray), tf.constant(Shape.of(4, 5)));
+      Operand<TFloat32> yPrediction =
+          tf.reshape(tf.constant(predictionArray), tf.constant(Shape.of(4, 5)));
+      Op op = instance.updateState(yTrue, yPrediction, null);
+      session.run(op);
+      Variable<TFloat32> total = instance.getTotal();
+      Variable<TFloat32> count = instance.getCount();
+      Operand<TFloat32> result = instance.result();
+      session.evaluate(0.96090573f, total);
+      session.evaluate(4f, count);
+      session.evaluate(0.24022f, result);
+    }
+  }
+
+  @Test
+  public void testWeighted() {
+    try (TestSession session = TestSession.createTestSession(tfMode)) {
+      Ops tf = session.getTF();
+      MeanSquaredLogarithmicError<TFloat64, TFloat64> instance =
+          new MeanSquaredLogarithmicError<>(tf, "MSLE_testWeighted", 1001L, TFloat64.class);
+      session.run(instance.resetStates());
+      session.evaluate(0.0, instance.getTotal());
+      session.evaluate(0, instance.getCount());
+      session.evaluate(0., instance.getCount());
+
+      int[] trueArray = {
+        0, 1, 0, 1, 0,
+        0, 0, 1, 1, 1,
+        1, 1, 1, 1, 0,
+        0, 0, 0, 0, 1
+      };
+      double[] predictionArray = {
+        0, 0, 1, 1, 0,
+        1, 1, 1, 1, 1,
+        0, 1, 0, 1, 0,
+        1, 1, 1, 1, 1
+      };
+      Operand<TInt32> yTrue = tf.reshape(tf.constant(trueArray), tf.constant(Shape.of(4, 5)));
+      Operand<TFloat64> yPrediction =
+          tf.reshape(tf.constant(predictionArray), tf.constant(Shape.of(4, 5)));
+
+      Operand<TFloat64> sampleWeight = tf.constant(new double[] {1., 1.5, 2., 2.5});
+      Op op = instance.updateState(yTrue, yPrediction, sampleWeight);
+      session.run(op);
+      Variable<TFloat64> total = instance.getTotal();
+      Variable<TFloat64> count = instance.getCount();
+      Operand<TFloat64> result = instance.result();
+      session.evaluate(1.8257208, total);
+      session.evaluate(7, count);
+      session.evaluate(0.26082, result);
+    }
+  }
+}

--- a/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/PoissonTest.java
+++ b/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/PoissonTest.java
@@ -1,0 +1,79 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================*/
+package org.tensorflow.framework.metrics;
+
+import org.junit.jupiter.api.Test;
+import org.tensorflow.Operand;
+import org.tensorflow.framework.utils.TestSession;
+import org.tensorflow.ndarray.Shape;
+import org.tensorflow.op.Op;
+import org.tensorflow.op.Ops;
+import org.tensorflow.op.core.Variable;
+import org.tensorflow.types.TFloat32;
+import org.tensorflow.types.TFloat64;
+import org.tensorflow.types.TInt32;
+
+class PoissonTest {
+  private final TestSession.Mode tfMode = TestSession.Mode.GRAPH;
+
+  @Test
+  public void testUnweighted() {
+    try (TestSession session = TestSession.createTestSession(tfMode)) {
+      Ops tf = session.getTF();
+      Poisson<TFloat32, TFloat64> instance =
+          new Poisson<>(tf, "Poisson_testUnweighted", 1001L, TFloat64.class);
+      session.run(instance.resetStates());
+      int[] trueArray = {4, 8, 12, 8, 1, 3};
+      float[] predArray = {1, 9, 2, 5, 2, 6};
+      Operand<TInt32> labels = tf.reshape(tf.constant(trueArray), tf.constant(Shape.of(2, 3)));
+      Operand<TFloat32> predictions =
+          tf.reshape(tf.constant(predArray), tf.constant(Shape.of(2, 3)));
+      Op op = instance.updateState(labels, predictions, null);
+      session.run(op);
+      Variable<TFloat64> total = instance.getTotal();
+      Variable<TFloat64> count = instance.getCount();
+      Operand<TFloat64> result = instance.result();
+      session.evaluate(-6.6131644, total);
+      session.evaluate(2, count);
+      session.evaluate(-3.3065822, result);
+    }
+  }
+
+  @Test
+  public void testWeighted() {
+    try (TestSession session = TestSession.createTestSession(tfMode)) {
+      Ops tf = session.getTF();
+      Poisson<TFloat32, TFloat32> instance =
+          new Poisson<>(tf, "Poisson_testWeighted", 1001L, TFloat32.class);
+      session.run(instance.resetStates());
+      int[] trueArray = {4, 8, 12, 8, 1, 3};
+      float[] predArray = {1, 9, 2, 5, 2, 6};
+
+      Operand<TInt32> labels = tf.reshape(tf.constant(trueArray), tf.constant(Shape.of(2, 3)));
+      Operand<TFloat32> predictions =
+          tf.reshape(tf.constant(predArray), tf.constant(Shape.of(2, 3)));
+
+      Operand<TFloat32> sampleWeight = tf.constant(new float[] {1.2f, 3.4f});
+      Op op = instance.updateState(labels, predictions, sampleWeight);
+      session.run(op);
+      Variable<TFloat32> total = instance.getTotal();
+      Variable<TFloat32> count = instance.getCount();
+      Operand<TFloat32> result = instance.result();
+      session.evaluate(-12.29468f, total);
+      session.evaluate(4.6f, count);
+      session.evaluate(-2.6727562f, result);
+    }
+  }
+}

--- a/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/SparseCategoricalCrossentropyTest.java
+++ b/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/SparseCategoricalCrossentropyTest.java
@@ -1,0 +1,129 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================*/
+package org.tensorflow.framework.metrics;
+
+import org.junit.jupiter.api.Test;
+import org.tensorflow.Operand;
+import org.tensorflow.framework.utils.TestSession;
+import org.tensorflow.ndarray.Shape;
+import org.tensorflow.op.Op;
+import org.tensorflow.op.Ops;
+import org.tensorflow.op.core.Variable;
+import org.tensorflow.types.TFloat32;
+import org.tensorflow.types.TFloat64;
+import org.tensorflow.types.TInt32;
+
+class SparseCategoricalCrossentropyTest {
+  private final TestSession.Mode tfMode = TestSession.Mode.GRAPH;
+
+  @Test
+  public void testUnweighted() {
+    try (TestSession session = TestSession.createTestSession(tfMode)) {
+      Ops tf = session.getTF();
+      SparseCategoricalCrossentropy<TFloat64, TFloat64> instance =
+          new SparseCategoricalCrossentropy<>(
+              tf, "SCE_testUnweighted", false, -1, 1001L, TFloat64.class);
+      session.run(instance.resetStates());
+      int[] trueArray = {1, 2};
+      double[] predictionArray = {0.05, 0.95, 0, 0.1, 0.8, 0.1};
+      Operand<TInt32> labels = tf.reshape(tf.constant(trueArray), tf.constant(Shape.of(2)));
+      Operand<TFloat64> predictions =
+          tf.reshape(tf.constant(predictionArray), tf.constant(Shape.of(2, 3)));
+      Op op = instance.updateState(labels, predictions, null);
+      session.run(op);
+      Variable<TFloat64> total = instance.getTotal();
+      Variable<TFloat64> count = instance.getCount();
+      Operand<TFloat64> result = instance.result();
+      session.evaluate(2.3538785, total);
+      session.evaluate(2, count);
+      session.evaluate(1.1769392, result);
+    }
+  }
+
+  @Test
+  public void testUnweightedLogits() {
+    try (TestSession session = TestSession.createTestSession(tfMode)) {
+      Ops tf = session.getTF();
+      SparseCategoricalCrossentropy<TFloat64, TFloat64> instance =
+          new SparseCategoricalCrossentropy<>(
+              tf, "SCE_testWeighted", true, -1, 1001L, TFloat64.class);
+      session.run(instance.resetStates());
+      int[] trueArray = {1, 2};
+      double[] logitsArray = {1, 9, 0, 1, 8, 1};
+      Operand<TInt32> labels = tf.reshape(tf.constant(trueArray), tf.constant(Shape.of(2)));
+      Operand<TFloat64> logits = tf.reshape(tf.constant(logitsArray), tf.constant(Shape.of(2, 3)));
+      Op op = instance.updateState(labels, logits, null);
+      session.run(op);
+      Variable<TFloat64> total = instance.getTotal();
+      Variable<TFloat64> count = instance.getCount();
+      Operand<TFloat64> result = instance.result();
+      session.evaluate(7.002277, total);
+      session.evaluate(2, count);
+      session.evaluate(3.501135, result);
+    }
+  }
+
+  @Test
+  public void testWeighted() {
+    try (TestSession session = TestSession.createTestSession(tfMode)) {
+      Ops tf = session.getTF();
+      SparseCategoricalCrossentropy<TFloat64, TFloat32> instance =
+          new SparseCategoricalCrossentropy<>(
+              tf, "SCE_testWeighted", false, -1, 1001L, TFloat32.class);
+      session.run(instance.resetStates());
+      int[] trueArray = {1, 2};
+      double[] predictionArray = {0.05, 0.95, 0, 0.1, 0.8, 0.1};
+      Operand<TInt32> labels = tf.reshape(tf.constant(trueArray), tf.constant(Shape.of(2)));
+      Operand<TFloat64> predictions =
+          tf.reshape(tf.constant(predictionArray), tf.constant(Shape.of(2, 3)));
+
+      Operand<TFloat32> sampleWeight = tf.constant(new float[] {1.5F, 2.F});
+      Op op = instance.updateState(labels, predictions, sampleWeight);
+      session.run(op);
+      Variable<TFloat32> total = instance.getTotal();
+      Variable<TFloat32> count = instance.getCount();
+      Operand<TFloat32> result = instance.result();
+      session.evaluate(4.6821103f, total);
+      session.evaluate(3.5f, count);
+      session.evaluate(1.3377458f, result);
+    }
+  }
+
+  @Test
+  public void testWeightedLogits() {
+    try (TestSession session = TestSession.createTestSession(tfMode)) {
+      Ops tf = session.getTF();
+      SparseCategoricalCrossentropy<TFloat64, TFloat64> instance =
+          new SparseCategoricalCrossentropy<>(
+              tf, "SCE_testWeighted", true, -1, 1001L, TFloat64.class);
+      session.run(instance.resetStates());
+      int[] trueArray = {1, 2};
+      double[] predictionArray = {1, 9, 0, 1, 8, 1};
+      Operand<TInt32> labels = tf.reshape(tf.constant(trueArray), tf.constant(Shape.of(2)));
+      Operand<TFloat64> predictions =
+          tf.reshape(tf.constant(predictionArray), tf.constant(Shape.of(2, 3)));
+
+      Operand<TFloat64> sampleWeight = tf.constant(new double[] {1.5, 2});
+      Op op = instance.updateState(labels, predictions, sampleWeight);
+      session.run(op);
+      Variable<TFloat64> total = instance.getTotal();
+      Variable<TFloat64> count = instance.getCount();
+      Operand<TFloat64> result = instance.result();
+      session.evaluate(14.004333, total);
+      session.evaluate(3.5, count);
+      session.evaluate(4.001232, result);
+    }
+  }
+}

--- a/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/SquaredHingeTest.java
+++ b/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/SquaredHingeTest.java
@@ -1,0 +1,90 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================*/
+package org.tensorflow.framework.metrics;
+
+import org.junit.jupiter.api.Test;
+import org.tensorflow.Operand;
+import org.tensorflow.framework.utils.TestSession;
+import org.tensorflow.ndarray.Shape;
+import org.tensorflow.op.Op;
+import org.tensorflow.op.Ops;
+import org.tensorflow.op.core.Variable;
+import org.tensorflow.types.TFloat32;
+import org.tensorflow.types.TFloat64;
+import org.tensorflow.types.TInt32;
+
+class SquaredHingeTest {
+  private final TestSession.Mode tfMode = TestSession.Mode.GRAPH;
+
+  @Test
+  public void testUnweighted() {
+    try (TestSession session = TestSession.createTestSession(tfMode)) {
+      Ops tf = session.getTF();
+      SquaredHinge<TFloat32, TFloat32> instance =
+          new SquaredHinge<>(tf, "SCE_testUnweighted", 1001L, TFloat32.class);
+      session.run(instance.resetStates());
+      int[] trueArray = {
+        0, 1, 0, 1,
+        0, 0, 1, 1
+      };
+      float[] predArray = {
+        -0.3f, 0.2f, -0.1f, 1.6f,
+        -0.25f, -1.f, 0.5f, 0.6f
+      };
+      Operand<TInt32> labels = tf.reshape(tf.constant(trueArray), tf.constant(Shape.of(2, 4)));
+      Operand<TFloat32> predictions =
+          tf.reshape(tf.constant(predArray), tf.constant(Shape.of(2, 4)));
+      Op op = instance.updateState(labels, predictions, null);
+      session.run(op);
+      Variable<TFloat32> total = instance.getTotal();
+      Variable<TFloat32> count = instance.getCount();
+      Operand<TFloat32> result = instance.result();
+      session.evaluate(0.72812f, total);
+      session.evaluate(2f, count);
+      session.evaluate(0.3640625f, result);
+    }
+  }
+
+  @Test
+  public void testWeighted() {
+    try (TestSession session = TestSession.createTestSession(tfMode)) {
+      Ops tf = session.getTF();
+      SquaredHinge<TFloat64, TFloat64> instance =
+          new SquaredHinge<>(tf, "SCE_testWeighted", 1001L, TFloat64.class);
+      session.run(instance.resetStates());
+      int[] trueArray = {
+        0, 1, 0, 1,
+        0, 0, 1, 1
+      };
+      double[] predArray = {
+        -0.3, 0.2, -0.1, 1.6,
+        -0.25, -1., 0.5, 0.6
+      };
+      Operand<TInt32> labels = tf.reshape(tf.constant(trueArray), tf.constant(Shape.of(2, 4)));
+      Operand<TFloat64> predictions =
+          tf.reshape(tf.constant(predArray), tf.constant(Shape.of(2, 4)));
+
+      Operand<TFloat64> sampleWeight = tf.constant(new double[] {1.5f, 2.f});
+      Op op = instance.updateState(labels, predictions, sampleWeight);
+      session.run(op);
+      Variable<TFloat64> total = instance.getTotal();
+      Variable<TFloat64> count = instance.getCount();
+      Operand<TFloat64> result = instance.result();
+      session.evaluate(1.2137499, total);
+      session.evaluate(3.5, count);
+      session.evaluate(0.3467857, result);
+    }
+  }
+}

--- a/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/impl/AssertBroadcastableTest.java
+++ b/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/impl/AssertBroadcastableTest.java
@@ -1,0 +1,292 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================*/
+package org.tensorflow.framework.metrics.impl;
+
+import org.junit.jupiter.api.Test;
+import org.tensorflow.Operand;
+import org.tensorflow.Tensor;
+import org.tensorflow.framework.utils.TestSession;
+import org.tensorflow.op.Op;
+import org.tensorflow.op.Ops;
+import org.tensorflow.types.TFloat32;
+import org.tensorflow.types.TFloat64;
+import org.tensorflow.types.TInt32;
+import org.tensorflow.types.TInt64;
+import org.tensorflow.types.family.TNumber;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class AssertBroadcastableTest {
+
+  private final TestSession.Mode tfMode = TestSession.Mode.GRAPH;
+
+  int[][][] valueArrayI =
+      new int[][][] {
+        {{1, 2, 3, 4}, {5, 6, 7, 8}},
+        {{9, 10, 11, 12}, {13, 14, 15, 16}},
+        {{17, 18, 19, 20}, {21, 22, 23, 24}}
+      };
+  long[][][] valueArrayL =
+      new long[][][] {
+        {{1, 2, 3, 4}, {5, 6, 7, 8}},
+        {{9, 10, 11, 12}, {13, 14, 15, 16}},
+        {{17, 18, 19, 20}, {21, 22, 23, 24}}
+      };
+  float[][][] valueArrayF =
+      new float[][][] {
+        {{1, 2, 3, 4}, {5, 6, 7, 8}},
+        {{9, 10, 11, 12}, {13, 14, 15, 16}},
+        {{17, 18, 19, 20}, {21, 22, 23, 24}}
+      };
+  double[][][] valueArrayD =
+      new double[][][] {
+        {{1, 2, 3, 4}, {5, 6, 7, 8}},
+        {{9, 10, 11, 12}, {13, 14, 15, 16}},
+        {{17, 18, 19, 20}, {21, 22, 23, 24}}
+      };
+
+  private <T extends TNumber> void testValid(
+      TestSession testSession, Ops tf, Operand<T> weights, Operand<T> values, Class<T> type) {
+
+    Op staticOp = MetricsHelper.assertBroadcastable(tf, weights, values);
+
+    // dynamic test
+    Operand<T> weightsPlaceholder = tf.placeholder(type);
+    Operand<T> valuesPlaceholder = tf.placeholder(type);
+
+    List<Tensor> tensors =
+        testSession.getGraphSession().runner().fetch(weights).fetch(values).run();
+    try (Tensor weightsTensor = tensors.get(0);
+        Tensor valuesTensor = tensors.get(1)) {
+      Op dynamicOp = MetricsHelper.assertBroadcastable(tf, weightsPlaceholder, valuesPlaceholder);
+
+      testSession
+          .getGraphSession()
+          .runner()
+          .feed(weightsPlaceholder, weightsTensor)
+          .feed(valuesPlaceholder, valuesTensor)
+          .addTarget(dynamicOp)
+          .run();
+    }
+  }
+
+  @Test
+  public void testValidScalar() {
+    // no exception should be thrown
+    try (TestSession testSession = TestSession.createTestSession(tfMode)) {
+      Ops tf = testSession.getTF();
+
+      Operand<TFloat32> values = tf.constant(valueArrayF);
+      Operand<TFloat32> weights = tf.constant(5f);
+      testValid(testSession, tf, weights, values, TFloat32.class);
+    }
+  }
+
+  @Test
+  public void test1x1x1() {
+    // no exception should be thrown
+    try (TestSession testSession = TestSession.createTestSession(tfMode)) {
+      Ops tf = testSession.getTF();
+
+      Operand<TFloat64> values = tf.constant(valueArrayD);
+      Operand<TFloat64> weights = tf.constant(new double[][][] {{{5}}});
+      testValid(testSession, tf, weights, values, TFloat64.class);
+    }
+  }
+
+  @Test
+  public void test1x1xN() {
+    // no exception should be thrown
+    try (TestSession testSession = TestSession.createTestSession(tfMode)) {
+      Ops tf = testSession.getTF();
+      Operand<TInt64> values = tf.constant(valueArrayL);
+      Operand<TInt64> weights = tf.constant(new long[][][] {{{5, 7, 11, 3}}});
+      testValid(testSession, tf, weights, values, TInt64.class);
+    }
+  }
+
+  @Test
+  public void test1xNx1() {
+    // no exception should be thrown
+    try (TestSession testSession = TestSession.createTestSession(tfMode)) {
+      Ops tf = testSession.getTF();
+      Operand<TInt32> values = tf.constant(valueArrayI);
+      Operand<TInt32> weights = tf.constant(new int[][][] {{{5}, {11}}});
+      testValid(testSession, tf, weights, values, TInt32.class);
+    }
+  }
+
+  @Test
+  public void test1xNxN() {
+    // no exception should be thrown
+    try (TestSession testSession = TestSession.createTestSession(tfMode)) {
+      Ops tf = testSession.getTF();
+
+      Operand<TInt32> values = tf.constant(valueArrayI);
+      Operand<TInt32> weights = tf.constant(new int[][][] {{{5, 7, 11, 3}, {2, 13, 7, 5}}});
+      testValid(testSession, tf, weights, values, TInt32.class);
+    }
+  }
+
+  @Test
+  public void testNx1x1() {
+    // no exception should be thrown
+    try (TestSession testSession = TestSession.createTestSession(tfMode)) {
+      Ops tf = testSession.getTF();
+
+      Operand<TInt32> values = tf.constant(valueArrayI);
+      Operand<TInt32> weights = tf.constant(new int[][][] {{{5}}, {{7}}, {{11}}});
+      testValid(testSession, tf, weights, values, TInt32.class);
+    }
+  }
+
+  @Test
+  public void testNx1xN() {
+    // no exception should be thrown
+    try (TestSession testSession = TestSession.createTestSession(tfMode)) {
+      Ops tf = testSession.getTF();
+
+      Operand<TInt32> values = tf.constant(valueArrayI);
+      Operand<TInt32> weights =
+          tf.constant(new int[][][] {{{5, 7, 11, 3}}, {{2, 12, 7, 5}}, {{2, 17, 11, 3}}});
+      testValid(testSession, tf, weights, values, TInt32.class);
+    }
+  }
+
+  @Test
+  public void testNxNxN() {
+    // no exception should be thrown
+    try (TestSession testSession = TestSession.createTestSession(tfMode)) {
+      Ops tf = testSession.getTF();
+
+      Operand<TInt32> values = tf.constant(valueArrayI);
+      Operand<TInt32> weights =
+          tf.constant(
+              new int[][][] {
+                {{5, 7, 11, 3}, {2, 12, 7, 5}},
+                {{2, 17, 11, 3}, {2, 17, 11, 3}},
+                {{5, 7, 11, 3}, {2, 12, 7, 5}}
+              });
+      testValid(testSession, tf, weights, values, TInt32.class);
+    }
+  }
+
+  // Note: For invalid tests, either NotBroadcastableException is thrown for static shapes or
+  // TFInvalidInvalidException is thrown for dynamic shapes. Both of these extend
+  // IllegalArgumentException,
+  // To simply the assertThrows, only IllegalArgumentException is expected.
+  // The private method, testValid, tests for both static and dynamic shapes.
+  @Test
+  public void testInvalid1x1() {
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          try (TestSession testSession = TestSession.createTestSession(tfMode)) {
+            Ops tf = testSession.getTF();
+            Operand<TInt32> values = tf.constant(valueArrayI);
+            Operand<TInt32> weights = tf.constant(new int[][] {{5}});
+            testValid(testSession, tf, weights, values, TInt32.class);
+          }
+        });
+  }
+
+  @Test
+  public void testInvalidPrefixMatch() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          try (TestSession testSession = TestSession.createTestSession(tfMode)) {
+            Ops tf = testSession.getTF();
+            Operand<TInt32> values = tf.constant(valueArrayI);
+            Operand<TInt32> weights = tf.constant(new int[][] {{5, 7}, {11, 3}, {2, 12}});
+            testValid(testSession, tf, weights, values, TInt32.class);
+          }
+        });
+  }
+
+  @Test
+  public void testInvalidSuffixMatch() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          try (TestSession testSession = TestSession.createTestSession(tfMode)) {
+            Ops tf = testSession.getTF();
+            Operand<TInt32> values = tf.constant(valueArrayI);
+            Operand<TInt32> weights = tf.constant(new int[][] {{5, 7, 11, 3}, {2, 12, 7, 5}});
+            testValid(testSession, tf, weights, values, TInt32.class);
+          }
+        });
+  }
+
+  @Test
+  public void testInvalidOnesExtraDim() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          try (TestSession testSession = TestSession.createTestSession(tfMode)) {
+            Ops tf = testSession.getTF();
+            Operand<TInt32> values = tf.constant(valueArrayI);
+            Operand<TInt32> weights = tf.constant(new int[][][][] {{{{5}}}});
+            testValid(testSession, tf, weights, values, TInt32.class);
+          }
+        });
+  }
+
+  @Test
+  public void testInvalidPrefixMatchExtraDim() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          try (TestSession testSession = TestSession.createTestSession(tfMode)) {
+            Ops tf = testSession.getTF();
+            Operand<TInt32> values = tf.constant(valueArrayI);
+
+            Operand<TInt32> weights =
+                tf.constant(
+                    new int[][][][] {
+                      {{{5}, {7}, {11}, {3}}, {{2}, {12}, {7}, {5}}},
+                      {{{2}, {17}, {11}, {3}}, {{2}, {17}, {11}, {3}}},
+                      {{{5}, {7}, {11}, {3}}, {{2}, {12}, {7}, {5}}}
+                    });
+            testValid(testSession, tf, weights, values, TInt32.class);
+          }
+        });
+  }
+
+  @Test
+  public void testInvalidSuffixMatchExtraDim() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          try (TestSession testSession = TestSession.createTestSession(tfMode)) {
+            Ops tf = testSession.getTF();
+            Operand<TInt32> values = tf.constant(valueArrayI);
+            Operand<TInt32> weights =
+                tf.constant(
+                    new int[][][][] {
+                      {
+                        {{5, 7, 11, 3}, {2, 12, 7, 5}},
+                        {{2, 17, 11, 3}, {2, 17, 11, 3}},
+                        {{5, 7, 11, 3}, {2, 12, 7, 5}}
+                      }
+                    });
+            testValid(testSession, tf, weights, values, TInt32.class);
+          }
+        });
+  }
+}

--- a/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/impl/BroadcastWeightsTest.java
+++ b/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/impl/BroadcastWeightsTest.java
@@ -1,0 +1,380 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=======================================================================*/
+package org.tensorflow.framework.metrics.impl;
+
+import org.junit.jupiter.api.Test;
+import org.tensorflow.Operand;
+import org.tensorflow.Tensor;
+import org.tensorflow.framework.utils.TestSession;
+import org.tensorflow.op.Ops;
+import org.tensorflow.types.TFloat32;
+import org.tensorflow.types.TFloat64;
+import org.tensorflow.types.TInt32;
+import org.tensorflow.types.TInt64;
+import org.tensorflow.types.family.TNumber;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class BroadcastWeightsTest {
+  private final TestSession.Mode tfMode = TestSession.Mode.GRAPH;
+
+  int[][][] valueArrayI =
+      new int[][][] {
+        {{1, 2, 3, 4}, {5, 6, 7, 8}},
+        {{9, 10, 11, 12}, {13, 14, 15, 16}},
+        {{17, 18, 19, 20}, {21, 22, 23, 24}}
+      };
+  long[][][] valueArrayL =
+      new long[][][] {
+        {{1, 2, 3, 4}, {5, 6, 7, 8}},
+        {{9, 10, 11, 12}, {13, 14, 15, 16}},
+        {{17, 18, 19, 20}, {21, 22, 23, 24}}
+      };
+  float[][][] valueArrayF =
+      new float[][][] {
+        {{1, 2, 3, 4}, {5, 6, 7, 8}},
+        {{9, 10, 11, 12}, {13, 14, 15, 16}},
+        {{17, 18, 19, 20}, {21, 22, 23, 24}}
+      };
+  double[][][] valueArrayD =
+      new double[][][] {
+        {{1, 2, 3, 4}, {5, 6, 7, 8}},
+        {{9, 10, 11, 12}, {13, 14, 15, 16}},
+        {{17, 18, 19, 20}, {21, 22, 23, 24}}
+      };
+
+  private <T extends TNumber> void testValid(
+      TestSession testSession,
+      Ops tf,
+      Operand<T> weights,
+      Operand<T> values,
+      Number[] expected, // flattened array
+      Class<T> type) {
+
+    Operand<T> staticOp = MetricsHelper.broadcastWeights(tf, weights, values);
+    if (expected != null) {
+      testSession.evaluate(expected, staticOp);
+    } else {
+      testSession.run(staticOp);
+    }
+
+    // dynamic test
+    Operand<T> weightsPlaceholder = tf.placeholder(type);
+    Operand<T> valuesPlaceholder = tf.placeholder(type);
+
+    List<Tensor> tensors =
+        testSession.getGraphSession().runner().fetch(weights).fetch(values).run();
+    try (Tensor weightsTensor = tensors.get(0);
+        Tensor valuesTensor = tensors.get(1)) {
+
+      Operand<T> dynamicOp =
+          MetricsHelper.broadcastWeights(tf, weightsPlaceholder, valuesPlaceholder);
+
+      List<Tensor> result =
+          testSession
+              .getGraphSession()
+              .runner()
+              .feed(weightsPlaceholder, weightsTensor)
+              .feed(valuesPlaceholder, valuesTensor)
+              .fetch(dynamicOp)
+              .run();
+
+      if (expected != null) {
+        if (type.equals(TInt32.class)) {
+          TInt32 intT = (TInt32) result.get(0);
+          AtomicInteger i = new AtomicInteger();
+          intT.scalars()
+              .forEachIndexed(
+                  (idx, f) -> assertEquals(expected[i.getAndIncrement()].intValue(), f.getInt()));
+        } else if (type.equals(TInt64.class)) {
+          TInt64 floatT = (TInt64) result.get(0);
+          AtomicInteger i = new AtomicInteger();
+          floatT
+              .scalars()
+              .forEachIndexed(
+                  (idx, f) -> assertEquals(expected[i.getAndIncrement()].longValue(), f.getLong()));
+        } else if (type.equals(TFloat32.class)) {
+          TFloat32 floatT = (TFloat32) result.get(0);
+          AtomicInteger i = new AtomicInteger();
+          floatT
+              .scalars()
+              .forEachIndexed(
+                  (idx, f) ->
+                      assertEquals(
+                          expected[i.getAndIncrement()].floatValue(), f.getFloat(), 1e-5F));
+        } else if (type.equals(TFloat64.class)) {
+          TFloat64 doubleT = (TFloat64) result.get(0);
+          AtomicInteger i = new AtomicInteger();
+          doubleT
+              .scalars()
+              .forEachIndexed(
+                  (idx, f) ->
+                      assertEquals(
+                          expected[i.getAndIncrement()].doubleValue(), f.getDouble(), 1e-5F));
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testValidScalar() {
+    // no exception should be thrown
+    try (TestSession testSession = TestSession.createTestSession(tfMode)) {
+      Ops tf = testSession.getTF();
+      Operand<TFloat32> values = tf.constant(valueArrayF);
+      Operand<TFloat32> weights = tf.constant(5f);
+      Float[] expected = {
+        5f, 5f, 5f, 5f, 5f, 5f, 5f, 5f, 5f, 5f, 5f, 5f, 5f, 5f, 5f, 5f, 5f, 5f, 5f, 5f, 5f, 5f, 5f,
+        5f
+      };
+      testValid(testSession, tf, weights, values, expected, TFloat32.class);
+    }
+  }
+
+  @Test
+  public void test1x1x1() {
+    // no exception should be thrown
+    try (TestSession testSession = TestSession.createTestSession(tfMode)) {
+      Ops tf = testSession.getTF();
+      Operand<TFloat64> values = tf.constant(valueArrayD);
+      Operand<TFloat64> weights = tf.constant(new double[][][] {{{5}}});
+      Double[] expected = {
+        5., 5., 5., 5., 5., 5., 5., 5., 5., 5., 5., 5., 5., 5., 5., 5., 5., 5., 5., 5., 5., 5., 5.,
+        5.
+      };
+
+      testValid(testSession, tf, weights, values, expected, TFloat64.class);
+    }
+  }
+
+  @Test
+  public void test1x1xN() {
+    // no exception should be thrown
+    try (TestSession testSession = TestSession.createTestSession(tfMode)) {
+      Ops tf = testSession.getTF();
+      Operand<TInt64> values = tf.constant(valueArrayL);
+      Operand<TInt64> weights = tf.constant(new long[][][] {{{5, 7, 11, 3}}});
+      Long[] expected = {
+        5L, 7L, 11L, 3L, 5L, 7L, 11L, 3L, 5L, 7L, 11L, 3L, 5L, 7L, 11L, 3L, 5L, 7L, 11L, 3L, 5L, 7L,
+        11L, 3L,
+      };
+      testValid(testSession, tf, weights, values, expected, TInt64.class);
+    }
+  }
+
+  @Test
+  public void test1xNx1() {
+    // no exception should be thrown
+    try (TestSession testSession = TestSession.createTestSession(tfMode)) {
+      Ops tf = testSession.getTF();
+      Operand<TInt32> values = tf.constant(valueArrayI);
+      Operand<TInt32> weights = tf.constant(new int[][][] {{{5}, {11}}});
+      Integer[] expected = {
+        5, 5, 5, 5, 11, 11, 11, 11, 5, 5, 5, 5, 11, 11, 11, 11, 5, 5, 5, 5, 11, 11, 11, 11
+      };
+      testValid(testSession, tf, weights, values, expected, TInt32.class);
+    }
+  }
+
+  @Test
+  public void test1xNxN() {
+    // no exception should be thrown
+    try (TestSession testSession = TestSession.createTestSession(tfMode)) {
+      Ops tf = testSession.getTF();
+      Operand<TInt32> values = tf.constant(valueArrayI);
+      Operand<TInt32> weights = tf.constant(new int[][][] {{{5, 7, 11, 3}, {2, 13, 7, 5}}});
+      Integer[] expected = {
+        5, 7, 11, 3, 2, 13, 7, 5, 5, 7, 11, 3, 2, 13, 7, 5, 5, 7, 11, 3, 2, 13, 7, 5,
+      };
+      testValid(testSession, tf, weights, values, expected, TInt32.class);
+    }
+  }
+
+  @Test
+  public void testNx1x1() {
+    // no exception should be thrown
+    try (TestSession testSession = TestSession.createTestSession(tfMode)) {
+      Ops tf = testSession.getTF();
+      Operand<TInt32> values = tf.constant(valueArrayI);
+      Operand<TInt32> weights = tf.constant(new int[][][] {{{5}}, {{7}}, {{11}}});
+      Integer[] expected = {
+        5, 5, 5, 5, 5, 5, 5, 5, 7, 7, 7, 7, 7, 7, 7, 7, 11, 11, 11, 11, 11, 11, 11, 11
+      };
+      testValid(testSession, tf, weights, values, expected, TInt32.class);
+    }
+  }
+
+  @Test
+  public void testNx1xN() {
+    // no exception should be thrown
+    try (TestSession testSession = TestSession.createTestSession(tfMode)) {
+      Ops tf = testSession.getTF();
+      Operand<TInt32> values = tf.constant(valueArrayI);
+      Operand<TInt32> weights =
+          tf.constant(new int[][][] {{{5, 7, 11, 3}}, {{2, 12, 7, 5}}, {{2, 17, 11, 3}}});
+      Integer[] expected = {
+        5, 7, 11, 3, 5, 7, 11, 3, 2, 12, 7, 5, 2, 12, 7, 5, 2, 17, 11, 3, 2, 17, 11, 3
+      };
+      testValid(testSession, tf, weights, values, expected, TInt32.class);
+    }
+  }
+
+  @Test
+  public void testNxNxN() {
+    // no exception should be thrown
+    try (TestSession testSession = TestSession.createTestSession(tfMode)) {
+      Ops tf = testSession.getTF();
+      Operand<TInt32> values = tf.constant(valueArrayI);
+
+      Operand<TInt32> weights =
+          tf.constant(
+              new int[][][] {
+                {{5, 7, 11, 3}, {2, 12, 7, 5}},
+                {{2, 17, 11, 3}, {2, 17, 11, 3}},
+                {{5, 7, 11, 3}, {2, 12, 7, 5}}
+              });
+      Integer[] expected = {
+        5, 7, 11, 3, 2, 12, 7, 5, 2, 17, 11, 3, 2, 17, 11, 3, 5, 7, 11, 3, 2, 12, 7, 5
+      };
+      testValid(testSession, tf, weights, values, expected, TInt32.class);
+    }
+  }
+
+  // Note: For invalid tests, either NotBroadcastableException is thrown for static shapes or
+  // TFInvalidInvalidException is thrown for dynamic shapes. Both of these extend
+  // IllegalArgumentException,
+  // To simply the assertThrows, only IllegalArgumentException is expected.
+  // The private method, testValid, tests for both static and dynamic shapes.
+  @Test
+  public void testInvalid1() {
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          try (TestSession testSession = TestSession.createTestSession(tfMode)) {
+            Ops tf = testSession.getTF();
+            Operand<TInt32> values = tf.constant(valueArrayI);
+            Operand<TInt32> weights = tf.constant(new int[] {5});
+
+            testValid(testSession, tf, weights, values, null, TInt32.class);
+          }
+        });
+  }
+
+  @Test
+  public void testInvalid1x1() {
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          try (TestSession testSession = TestSession.createTestSession(tfMode)) {
+            Ops tf = testSession.getTF();
+            Operand<TInt32> values = tf.constant(valueArrayI);
+            Operand<TInt32> weights = tf.constant(new int[][] {{5}});
+
+            testValid(testSession, tf, weights, values, null, TInt32.class);
+          }
+        });
+  }
+
+  @Test
+  public void testInvalidPrefixMatch() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          try (TestSession testSession = TestSession.createTestSession(tfMode)) {
+            Ops tf = testSession.getTF();
+            Operand<TInt32> values = tf.constant(valueArrayI);
+            Operand<TInt32> weights = tf.constant(new int[][] {{5, 7}, {11, 3}, {2, 12}});
+            testValid(testSession, tf, weights, values, null, TInt32.class);
+          }
+        });
+  }
+
+  @Test
+  public void testInvalidSuffixMatch() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          try (TestSession testSession = TestSession.createTestSession(tfMode)) {
+            Ops tf = testSession.getTF();
+            Operand<TInt32> values = tf.constant(valueArrayI);
+            Operand<TInt32> weights = tf.constant(new int[][] {{5, 7, 11, 3}, {2, 12, 7, 5}});
+            testValid(testSession, tf, weights, values, null, TInt32.class);
+          }
+        });
+  }
+
+  @Test
+  public void testInvalidOnesExtraDim() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          try (TestSession testSession = TestSession.createTestSession(tfMode)) {
+            Ops tf = testSession.getTF();
+            Operand<TInt32> values = tf.constant(valueArrayI);
+            Operand<TInt32> weights = tf.constant(new int[][][][] {{{{5}}}});
+            testValid(testSession, tf, weights, values, null, TInt32.class);
+          }
+        });
+  }
+
+  @Test
+  public void testInvalidPrefixMatchExtraDim() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          try (TestSession testSession = TestSession.createTestSession(tfMode)) {
+            Ops tf = testSession.getTF();
+            Operand<TInt32> values = tf.constant(valueArrayI);
+
+            Operand<TInt32> weights =
+                tf.constant(
+                    new int[][][][] {
+                      {{{5}, {7}, {11}, {3}}, {{2}, {12}, {7}, {5}}},
+                      {{{2}, {17}, {11}, {3}}, {{2}, {17}, {11}, {3}}},
+                      {{{5}, {7}, {11}, {3}}, {{2}, {12}, {7}, {5}}}
+                    });
+            testValid(testSession, tf, weights, values, null, TInt32.class);
+          }
+        });
+  }
+
+  @Test
+  public void testInvalidSuffixMatchExtraDim() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          try (TestSession testSession = TestSession.createTestSession(tfMode)) {
+            Ops tf = testSession.getTF();
+            Operand<TInt32> values = tf.constant(valueArrayI);
+            Operand<TInt32> weights =
+                tf.constant(
+                    new int[][][][] {
+                      {
+                        {{5, 7, 11, 3}, {2, 12, 7, 5}},
+                        {{2, 17, 11, 3}, {2, 17, 11, 3}},
+                        {{5, 7, 11, 3}, {2, 12, 7, 5}}
+                      }
+                    });
+            testValid(testSession, tf, weights, values, null, TInt32.class);
+          }
+        });
+  }
+}

--- a/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/impl/SetsOpsTest.java
+++ b/tensorflow-framework/src/test/java/org/tensorflow/framework/metrics/impl/SetsOpsTest.java
@@ -1,0 +1,120 @@
+package org.tensorflow.framework.metrics.impl;
+
+import org.junit.jupiter.api.Test;
+import org.tensorflow.Operand;
+import org.tensorflow.framework.utils.TestSession;
+import org.tensorflow.ndarray.Shape;
+import org.tensorflow.op.Ops;
+import org.tensorflow.types.TInt32;
+import org.tensorflow.types.TInt64;
+import org.tensorflow.types.TUint8;
+import org.tensorflow.types.family.TType;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.tensorflow.framework.utils.CastHelper.cast;
+
+class SetsOpsTest {
+
+  private final TestSession.Mode[] tfModes = {TestSession.Mode.EAGER, TestSession.Mode.GRAPH};
+
+  List<Class<? extends TType>> types = Arrays.asList(TInt32.class, TInt64.class, TUint8.class);
+
+  @Test
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public void testSetIntersectionMultirow2() {
+
+    for (TestSession.Mode tfMode : tfModes)
+      try (TestSession session = TestSession.createTestSession(tfMode)) {
+        Ops tf = session.getTF();
+        Operand<TInt32> a = tf.constant(new int[][] {{9, 1, 5}, {2, 4, 3}});
+        Operand<TInt32> b = tf.constant(new int[][] {{1, 9}, {1, 5}});
+        int[][] expected = new int[][] {{1, 9}, {0, 0}};
+        Shape expectedShape = Shape.of(2, 2);
+        for (Class<? extends TType> type : types) {
+          Operand aa = cast(tf, a, type);
+          Operand bb = cast(tf, b, type);
+          Operand<? extends TType> intersection = SetsOps.intersection(tf, aa, bb);
+          session.evaluate(cast(tf, tf.constant(expected), type), intersection);
+          session.evaluate(tf.constant(expectedShape), tf.shape(intersection, TInt64.class));
+        }
+      }
+  }
+
+  @Test
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public void testSetIntersectionDuplicates2d() {
+
+    for (TestSession.Mode tfMode : tfModes)
+      try (TestSession session = TestSession.createTestSession(tfMode)) {
+        Ops tf = session.getTF();
+        Operand<TInt32> a = tf.constant(new int[][] {{1, 1, 3}});
+        Operand<TInt32> b = tf.constant(new int[][] {{1, 1}});
+        int[][] expected = {{1}};
+        Shape expectedShape = Shape.of(1, 1);
+        for (Class<? extends TType> type : types) {
+          Operand aa = cast(tf, a, type);
+          Operand bb = cast(tf, b, type);
+          Operand intersection = SetsOps.intersection(tf, aa, bb);
+
+          session.evaluate(cast(tf, tf.constant(expected), type), intersection);
+
+          session.evaluate(tf.constant(expectedShape), tf.shape(intersection, TInt64.class));
+        }
+      }
+  }
+
+  @Test
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public void testDenseSetDifferenceMultirow2d() {
+
+    for (TestSession.Mode tfMode : tfModes)
+      try (TestSession session = TestSession.createTestSession(tfMode)) {
+        Ops tf = session.getTF();
+        Operand<TInt32> a = tf.constant(new int[][] {{1, 5, 9}, {4, 5, 3}});
+        Operand<TInt32> b = tf.constant(new int[][] {{1, 2, 6}, {1, 2, 2}});
+
+        for (Class<? extends TType> type : types) {
+          Operand aa = cast(tf, a, type);
+          Operand bb = cast(tf, b, type);
+          int[][] expected = {{5, 9, 0}, {3, 4, 5}};
+          // a- b
+          Shape expectedShape = Shape.of(2, 3);
+          Operand intersection = SetsOps.difference(tf, aa, bb);
+          session.evaluate(cast(tf, tf.constant(expected), type), intersection);
+          session.evaluate(tf.constant(expectedShape), tf.shape(intersection, TInt64.class));
+
+          // b - a
+          expected = new int[][] {{2, 6}, {1, 2}};
+          expectedShape = Shape.of(2, 2);
+          intersection = SetsOps.difference(tf, aa, bb, false);
+
+          session.evaluate(cast(tf, tf.constant(expected), type), intersection);
+          session.evaluate(tf.constant(expectedShape), tf.shape(intersection, TInt64.class));
+        }
+      }
+  }
+
+  @Test
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public void testDenseUnionMultirow2d() {
+
+    for (TestSession.Mode tfMode : tfModes)
+      try (TestSession session = TestSession.createTestSession(tfMode)) {
+        Ops tf = session.getTF();
+        Operand<TInt32> a = tf.constant(new int[][] {{9, 1, 5}, {2, 4, 3}});
+        Operand<TInt32> b = tf.constant(new int[][] {{1, 9}, {1, 2}});
+        int[][] expected = new int[][] {{5, 0}, {3, 4}};
+        for (Class<? extends TType> type : types) {
+          Operand aa = cast(tf, a, type);
+          Operand bb = cast(tf, b, type);
+          Shape expectedShape = Shape.of(2, 2);
+          // a- b
+          Operand intersection = SetsOps.difference(tf, aa, bb);
+          session.evaluate(cast(tf, tf.constant(expected), type), intersection);
+          session.evaluate(tf.constant(expectedShape), tf.shape(intersection, TInt64.class));
+        }
+      }
+  }
+}

--- a/tensorflow-framework/src/test/java/org/tensorflow/framework/utils/GraphTestSession.java
+++ b/tensorflow-framework/src/test/java/org/tensorflow/framework/utils/GraphTestSession.java
@@ -213,10 +213,13 @@ public class GraphTestSession extends TestSession {
   @Override
   public <T extends TNumber> void evaluate(Number[] expected, Output<T> input) {
     int size = input.shape().size() == 0 ? 1 : (int) input.shape().size();
-    assertEquals(
-        expected.length,
-        size,
-        () -> String.format("expected length (%d) != to input length (%d)", expected.length, size));
+    if (size != Shape.UNKNOWN_SIZE) {
+      assertEquals(
+          expected.length,
+          size,
+          () ->
+              String.format("expected length (%d) != to input length (%d)", expected.length, size));
+    }
     Class<T> inputType = input.type();
     if (inputType == TFloat32.class) {
       AtomicInteger index = new AtomicInteger();
@@ -425,10 +428,13 @@ public class GraphTestSession extends TestSession {
   @Override
   public void evaluate(String[] expected, Output<TString> input) {
     int size = input.shape().size() == 0 ? 1 : (int) input.shape().size();
-    assertEquals(
-        expected.length,
-        size,
-        () -> String.format("expected length (%d) != to input length (%d)", expected.length, size));
+    if (size != Shape.UNKNOWN_SIZE) {
+      assertEquals(
+          expected.length,
+          size,
+          () ->
+              String.format("expected length (%d) != to input length (%d)", expected.length, size));
+    }
     AtomicInteger index = new AtomicInteger();
     if (debug) {
       try (TString result =
@@ -1025,7 +1031,7 @@ public class GraphTestSession extends TestSession {
           (TFloat64)this.getGraphSession().runner().fetch(input).run().get(0)) {
         if (isScalar) {
           writer.printf(
-              "%d). %f\n", index.getAndIncrement(), ((Output<TFloat64>) input).asTensor().getDouble());
+              "%d). %f\n", index.getAndIncrement(), result.getDouble());
         } else {
           result
               .scalars()
@@ -1040,7 +1046,7 @@ public class GraphTestSession extends TestSession {
           (TInt32)this.getGraphSession().runner().fetch(input).run().get(0)) {
         if (isScalar) {
           writer.printf(
-              "%d). %d\n", index.getAndIncrement(), ((Output<TInt32>) input).asTensor().getInt());
+              "%d). %d\n", index.getAndIncrement(),result.getInt());
         } else {
           result
               .scalars()
@@ -1055,7 +1061,7 @@ public class GraphTestSession extends TestSession {
           (TInt64)this.getGraphSession().runner().fetch(input).run().get(0)) {
         if (isScalar) {
           writer.printf(
-              "%d). %d\n", index.getAndIncrement(), ((Output<TInt64>) input).asTensor().getLong());
+              "%d). %d\n", index.getAndIncrement(), result.getLong());
         } else {
           result
               .scalars()
@@ -1070,7 +1076,7 @@ public class GraphTestSession extends TestSession {
           (TUint8)this.getGraphSession().runner().fetch(input).run().get(0)) {
         if (isScalar) {
           writer.printf(
-              "%d). %x\n", index.getAndIncrement(), ((Output<TUint8>) input).asTensor().getByte());
+              "%d). %x\n", index.getAndIncrement(), result.getByte());
         } else {
           result
               .scalars()
@@ -1085,7 +1091,7 @@ public class GraphTestSession extends TestSession {
           (TBool)this.getGraphSession().runner().fetch(input).run().get(0)) {
         if (isScalar) {
           writer.printf(
-              "%d). %b\n", index.getAndIncrement(), ((Output<TBool>) input).asTensor().getBoolean());
+              "%d). %b\n", index.getAndIncrement(), result.getBoolean());
         } else {
           result
               .scalars()
@@ -1100,7 +1106,7 @@ public class GraphTestSession extends TestSession {
           (TString)this.getGraphSession().runner().fetch(input).run().get(0)) {
         if (isScalar) {
           writer.printf(
-              "%d). %s\n", index.getAndIncrement(), ((Output<TString>) input).asTensor().getObject());
+              "%d). %s\n", index.getAndIncrement(), result.getObject());
         } else {
           result
               .scalars()

--- a/tensorflow-framework/src/test/java/org/tensorflow/framework/utils/TestSession.java
+++ b/tensorflow-framework/src/test/java/org/tensorflow/framework/utils/TestSession.java
@@ -493,6 +493,16 @@ public abstract class TestSession implements AutoCloseable {
   }
 
   /**
+   * Print the input to standard out
+   *
+
+   * @param input the operand to print
+   * @param <T> the data type of the input
+   */
+  public <T extends TType> void print(Operand<T> input) {
+    print(new PrintWriter(new OutputStreamWriter(System.out)), input.asOutput());
+  }
+  /**
    * Print the input
    *
    * @param out the output stream
@@ -504,6 +514,15 @@ public abstract class TestSession implements AutoCloseable {
   }
 
   /**
+   * Print the input to standard out
+   *
+   * @param input the op to print
+   */
+  public void print(Op input) {
+    print(new PrintWriter(new OutputStreamWriter(System.out)), input.op().output(0));
+  }
+
+  /**
    * Print the input
    *
    * @param out the output stream
@@ -511,6 +530,16 @@ public abstract class TestSession implements AutoCloseable {
    */
   public void print(OutputStream out, Op input) {
     print(new PrintWriter(new OutputStreamWriter(out)), input.op().output(0));
+  }
+
+  /**
+   * Print the input to standard out
+   *
+   * @param input the op to print
+   * @param <T> the data type of the input
+   */
+  public <T extends TType> void print(Output<T> input) {
+    print(new PrintWriter(new OutputStreamWriter(System.out)), input);
   }
 
   /**


### PR DESCRIPTION
* Initial checkin

* Initial checkin and sync with master

* Initial checkin and sync with master

* JavaDoc cleanup

* Javadoc fixes

* Change LossInterface to LossMetric.
Fix JavaDoc,
modify one line code block to include braces.

* Removed hashmap for variables, they are not needed as the variables only live within a single instance of a Metric.

* reformat code

* Add tests for assertBroadcastable

* Change type to resultType

* Added V data type for sampleWeights so that it is not forced to be the same type as the return or internal variables,

* change 'type' to 'resultType'

* clean up mean and fix assert assertBroadcastable

* fix error message

* Change sampleWeights to have its own generic type <S extends TNumber>

* Add commment about invalid tests expecting IllegalArgumentExceptions

* Add this exception instead of the more generic IllegalArgumentException when static shapes cannot boradcast.

* change IllegalArgumentException to NotBroadcastableException.
change hasValidNonscalarShape to canBroadcastNonscalarShapes
change hasValidNonscalarShape to canBroadcastNonscalarShapes

* reformat code

* Fis=x Javadoc
move the dynamic shapes and rank down to the dynamic section so they are created needlessly when static
Fix if statement to check for unknown size and unknown dimensions

* Fix Reduce to use boradcastWeights,
renamed WeightBroadcastTest to AssertBroadcastableTest and added BroadcastWeightsTest

* Added comment to count to indicate that it may be weighted.

* Added SetsOps and fixed AssertBroadcastable to use SetsOps methods,

* Fixed based on various PR comments.

* Deleted, no longer needed after change to Variable handling in Metrics.

* Nicer error messages for mode-forbidden ops (#169)

* start fobbiden ops checks

Signed-off-by: Ryan Nett <rnett@calpoly.edu>

* fix style

Signed-off-by: Ryan Nett <rnett@calpoly.edu>

* move checks to builder method

Signed-off-by: Ryan Nett <rnett@calpoly.edu>

* Initialization imprvements (#178)

* No-op on initAdd in eager mode

Signed-off-by: Ryan Nett <rnett@calpoly.edu>

* runInit() method in session

Signed-off-by: Ryan Nett <rnett@calpoly.edu>

* add doInitialization() to Runner

Signed-off-by: Ryan Nett <rnett@calpoly.edu>

* fix javadoc

Signed-off-by: Ryan Nett <rnett@calpoly.edu>

* assume only graph or eager environments

Signed-off-by: Ryan Nett <rnett@calpoly.edu>

* Remove doInit(), update javadocs

Signed-off-by: Ryan Nett <rnett@calpoly.edu>

* small fixes

Signed-off-by: Ryan Nett <rnett@calpoly.edu>

* Clairify tensorOf lifetime requirements (#190)

* Clairify tensorOf lifetime requirements

Signed-off-by: Ryan Nett <rnett@calpoly.edu>

* Do codegen

Signed-off-by: Ryan Nett <rnett@calpoly.edu>

* Remove extra generics from op generation (#193)

* Successfully remove extra type params, but it broke javadoc generation

Signed-off-by: Ryan Nett <rnett@calpoly.edu>

* Generate covariant types

Signed-off-by: Ryan Nett <rnett@calpoly.edu>

* Do generation

Signed-off-by: Ryan Nett <rnett@calpoly.edu>

* Update help text.

Signed-off-by: Ryan Nett <rnett@calpoly.edu>

* Fixes

Signed-off-by: Ryan Nett <rnett@calpoly.edu>

* Add Java 11 support - Initial Phase (#185)

* Add profile for JDK11 and  Automatic-Module-Name to jars

* add maven.compiler.release=11

* Update manual ops for new codegen (#196)

Signed-off-by: Ryan Nett <rnett@calpoly.edu>

* Fix Losses to use CHANNELS_FIRST/LAST for CategoricalCrossentropy

* Fix SetOps to properly convert sparse tensor to dense tensor using tf.sparse.sparseToDense with the output of tf.sparse.denseToDenseSetOperation

* Initial checkin

* Initial checkin and sync with master

* Initial checkin and sync with master

* JavaDoc cleanup

* Javadoc fixes

* Change LossInterface to LossMetric.
Fix JavaDoc,
modify one line code block to include braces.

* Removed hashmap for variables, they are not needed as the variables only live within a single instance of a Metric.

* reformat code

* Add tests for assertBroadcastable

* Change type to resultType

* Added V data type for sampleWeights so that it is not forced to be the same type as the return or internal variables,

* change 'type' to 'resultType'

* clean up mean and fix assert assertBroadcastable

* fix error message

* Change sampleWeights to have its own generic type <S extends TNumber>

* Add commment about invalid tests expecting IllegalArgumentExceptions

* Add this exception instead of the more generic IllegalArgumentException when static shapes cannot boradcast.

* change IllegalArgumentException to NotBroadcastableException.
change hasValidNonscalarShape to canBroadcastNonscalarShapes
change hasValidNonscalarShape to canBroadcastNonscalarShapes

* reformat code

* Fis=x Javadoc
move the dynamic shapes and rank down to the dynamic section so they are created needlessly when static
Fix if statement to check for unknown size and unknown dimensions

* Fix Reduce to use boradcastWeights,
renamed WeightBroadcastTest to AssertBroadcastableTest and added BroadcastWeightsTest

* Added comment to count to indicate that it may be weighted.

* Added SetsOps and fixed AssertBroadcastable to use SetsOps methods,

* Fixed based on various PR comments.

* Deleted, no longer needed after change to Variable handling in Metrics.

* Fix Losses to use CHANNELS_FIRST/LAST for CategoricalCrossentropy

* Fix SetOps to properly convert sparse tensor to dense tensor using tf.sparse.sparseToDense with the output of tf.sparse.denseToDenseSetOperation

Co-authored-by: Ryan Nett <rnett@calpoly.edu>